### PR TITLE
Generate imports in sorted path order

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -26,6 +26,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -213,12 +214,18 @@ func (g *generator) Generate(pkg *model.Package, pkgName string) error {
 	g.p("")
 	g.p("import (")
 	g.in()
-	for path, pkg := range g.packageMap {
+	var paths []string
+	for path := range g.packageMap {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
 		if path == *selfPackage {
 			continue
 		}
-		g.p("%v %q", pkg, path)
+		g.p("%v %q", g.packageMap[path], path)
 	}
+	sort.Strings(pkg.DotImports)
 	for _, path := range pkg.DotImports {
 		g.p(". %q", path)
 	}


### PR DESCRIPTION
This change ensures that the import order is consistent between multiple runs of mockgen (rather than in random map iteration order).  This is useful to help avoid noisy diffs for the case where multiple mocks are regenerated automatically but not all of the mocked interfaces have changed.