### PR TITLE
Lambda matcher and more validation methods

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 )
 
+const infinity = 1e8 // close enough to infinity
+
 // Call represents an expected call to a mock.
 type Call struct {
 	t TestReporter // for triggering test failures on invalid call setup
@@ -42,7 +44,19 @@ type Call struct {
 }
 
 func (c *Call) AnyTimes() *Call {
-	c.minCalls, c.maxCalls = 0, 1e8 // close enough to infinity
+	c.minCalls, c.maxCalls = 0, infinity
+	return c
+}
+
+// AtLeast specifies that a mocked method should be invoked callCount time as minimum (inclusive).
+func (c *Call) AtLeast(callCount int) *Call {
+	c.minCalls, c.maxCalls = callCount, infinity
+	return c
+}
+
+// AtMost specifies that a mocked method should be invoked callCount time as maximum (inclusive).
+func (c *Call) AtMost(callCount int) *Call {
+	c.minCalls, c.maxCalls = 0, callCount
 	return c
 }
 

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -210,6 +210,39 @@ func TestAnyTimes(t *testing.T) {
 	ctrl.Finish()
 }
 
+func TestAtMost(t *testing.T) {
+	reporter, ctrl := createFixtures(t)
+	subject := new(Subject)
+
+	ctrl.RecordCall(subject, "FooMethod", "argument").AtMost(3)
+	ctrl.Call(subject, "FooMethod", "argument")
+	ctrl.Call(subject, "FooMethod", "argument")
+	ctrl.Call(subject, "FooMethod", "argument")
+	reporter.assertPass("After expected repeated method calls.")
+	reporter.assertFatal(func() {
+		ctrl.Call(subject, "FooMethod", "argument")
+	})
+	ctrl.Finish()
+	reporter.assertFail("After calling one too many times.")
+}
+
+func TestAtLeast(t *testing.T) {
+	reporter, ctrl := createFixtures(t)
+	subject := new(Subject)
+
+	ctrl.RecordCall(subject, "FooMethod", "argument").AtLeast(2)
+	ctrl.Call(subject, "FooMethod", "argument")
+
+	reporter.assertFatal(func() {
+		ctrl.Finish()
+	})
+
+	reporter.assertFail("After calling one too many times.")
+
+	ctrl.Call(subject, "FooMethod", "argument")
+	ctrl.Finish()
+}
+
 func TestDo(t *testing.T) {
 	_, ctrl := createFixtures(t)
 	subject := new(Subject)

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -39,6 +39,21 @@ func (anyMatcher) String() string {
 	return "is anything"
 }
 
+// lambdaMatcher allows matching generic function against a custom lambda
+type lambdaMatcher struct {
+	f interface{}
+}
+
+func (e lambdaMatcher) Matches(x interface{}) bool {
+	f := reflect.ValueOf(e.f)
+	result := f.Call([]reflect.Value{reflect.ValueOf(x)})[0]
+	return result.Bool()
+}
+
+func (e lambdaMatcher) String() string {
+	return fmt.Sprintf("lambda matcher")
+}
+
 type eqMatcher struct {
 	x interface{}
 }
@@ -86,9 +101,10 @@ func (n notMatcher) String() string {
 }
 
 // Constructors
-func Any() Matcher             { return anyMatcher{} }
-func Eq(x interface{}) Matcher { return eqMatcher{x} }
-func Nil() Matcher             { return nilMatcher{} }
+func Any() Matcher                 { return anyMatcher{} }
+func Lambda(x interface{}) Matcher { return lambdaMatcher{x} }
+func Eq(x interface{}) Matcher     { return eqMatcher{x} }
+func Nil() Matcher                 { return nilMatcher{} }
 func Not(x interface{}) Matcher {
 	if m, ok := x.(Matcher); ok {
 		return notMatcher{m}

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -30,6 +30,7 @@ func TestMatchers(t *testing.T) {
 	}
 	tests := []testCase{
 		testCase{gomock.Any(), []e{3, nil, "foo"}, nil},
+		testCase{gomock.Lambda(func(x int) bool { return x == 3 }), []e{3}, []e{1, 2}},
 		testCase{gomock.Eq(4), []e{4}, []e{3, "blah", nil, int64(4)}},
 		testCase{gomock.Nil(),
 			[]e{nil, (error)(nil), (chan bool)(nil), (*int)(nil)},


### PR DESCRIPTION
Lambda matcher allows comparing complex expressions compare instead of
eq or any
-- AtMost and AtLeast call validator (take a look at the following
variety  in the moq library)
http://www.nudoq.org/#!/Packages/Moq/Moq/Times

Signed-off-by: Liron Levin <liron@twistlock.com>