### PR TITLE
add import_prefix to specify a vendored gomock pkg

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -40,10 +40,11 @@ const (
 )
 
 var (
-	source      = flag.String("source", "", "(source mode) Input Go source file; enables source mode.")
-	destination = flag.String("destination", "", "Output file; defaults to stdout.")
-	packageOut  = flag.String("package", "", "Package of the generated code; defaults to the package of the input with a 'mock_' prefix.")
-	selfPackage = flag.String("self_package", "", "If set, the package this mock will be part of.")
+	source       = flag.String("source", "", "(source mode) Input Go source file; enables source mode.")
+	destination  = flag.String("destination", "", "Output file; defaults to stdout.")
+	packageOut   = flag.String("package", "", "Package of the generated code; defaults to the package of the input with a 'mock_' prefix.")
+	selfPackage  = flag.String("self_package", "", "If set, the package this mock will be part of.")
+	importPrefix = flag.String("import_prefix", "", "If set, the prefix for the import of the gomock package")
 
 	debugParser = flag.Bool("debug_parser", false, "Print out parser results only.")
 )
@@ -190,7 +191,8 @@ func (g *generator) Generate(pkg *model.Package, pkgName string) error {
 
 	// Get all required imports, and generate unique names for them all.
 	im := pkg.Imports()
-	im[gomockImportPath] = true
+	gomockPath := path.Join(*importPrefix, gomockImportPath)
+	im[gomockPath] = true
 	g.packageMap = make(map[string]string, len(im))
 	localNames := make(map[string]bool, len(im))
 	for pth := range im {


### PR DESCRIPTION
The import_prefix flag allows a user of mockgen to specify that they want the gomock library they have vendored (by say, Godeps) to be used instead of the normal one.

It avoids having to remember to call things like `godep save -r` when adding new mocks.

Idea taken from import_prefix in the protoc-gen-go code.