### PR TITLE
Add mock_prefix flag to specify custom mocked function names

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -44,6 +44,7 @@ var (
 	destination = flag.String("destination", "", "Output file; defaults to stdout.")
 	packageOut  = flag.String("package", "", "Package of the generated code; defaults to the package of the input with a 'mock_' prefix.")
 	selfPackage = flag.String("self_package", "", "If set, the package this mock will be part of.")
+	mockPrefix  = flag.String("mock_prefix", "", "If set, adds prefix to the mocked function names.")
 
 	debugParser = flag.Bool("debug_parser", false, "Print out parser results only.")
 )
@@ -239,7 +240,7 @@ func (g *generator) Generate(pkg *model.Package, pkgName string) error {
 
 // The name of the mock type to use for the given interface identifier.
 func mockName(typeName string) string {
-	return "Mock" + typeName
+	return "Mock" + *mockPrefix + typeName
 }
 
 func (g *generator) GenerateMockInterface(intf *model.Interface) error {


### PR DESCRIPTION
I have two interfaces in different packages with the same name:

```go
package package1

type Client interface {
    Method1()
}
```

```go
package package2

type Client interface {
    Method2()
}
```

I want to generate mocks for them. The problem is that it generates mocks with the same function names:
```go
func NewMockClient(ctrl *gomock.Controller) *MockClient {
	mock := &MockClient{ctrl: ctrl}
	mock.recorder = &_MockClientRecorder{mock}
	return mock
}
```

Added `mock_prefix` flag allows a user to specify a custom prefix for mocked names:
```go
func NewMockPackage1Client(ctrl *gomock.Controller) *MockPackage1Client {
	mock := &MockPackage1Client{ctrl: ctrl}
	mock.recorder = &_MockPackage1ClientRecorder{mock}
	return mock
}
```

```go
func NewMockPackage2Client(ctrl *gomock.Controller) *MockPackage2Client {
	mock := &MockPackage2Client{ctrl: ctrl}
	mock.recorder = &_MockPackage2ClientRecorder{mock}
	return mock
}
```