### PR TITLE
Add AtLeastOnce() method

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -46,6 +46,11 @@ func (c *Call) AnyTimes() *Call {
 	return c
 }
 
+func (c *Call) AtLeastOnce() *Call {
+	c.minCalls, c.maxCalls = 1, 1e8 // close enough to infinity
+	return c
+}
+
 // Do declares the action to run when the call is matched.
 // It takes an interface{} argument to support n-arity functions.
 func (c *Call) Do(f interface{}) *Call {

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -210,6 +210,32 @@ func TestAnyTimes(t *testing.T) {
 	ctrl.Finish()
 }
 
+func TestAtLeastOnce(t *testing.T) {
+	// It fails if there are no calls
+	reporter, ctrl := createFixtures(t)
+	subject := new(Subject)
+	ctrl.RecordCall(subject, "FooMethod", "argument").AtLeastOnce()
+	reporter.assertFatal(func() {
+		ctrl.Finish()
+	})
+
+	// It succeeds if there is one call
+	reporter, ctrl = createFixtures(t)
+	subject = new(Subject)
+	ctrl.RecordCall(subject, "FooMethod", "argument").AtLeastOnce()
+	ctrl.Call(subject, "FooMethod", "argument")
+	ctrl.Finish()
+
+	// It succeeds if there are many calls
+	reporter, ctrl = createFixtures(t)
+	subject = new(Subject)
+	ctrl.RecordCall(subject, "FooMethod", "argument").AtLeastOnce()
+	for i := 0; i < 100; i++ {
+		ctrl.Call(subject, "FooMethod", "argument")
+	}
+	ctrl.Finish()
+}
+
 func TestDo(t *testing.T) {
 	_, ctrl := createFixtures(t)
 	subject := new(Subject)


### PR DESCRIPTION
Allows a test to ensure that a call happens at least
one time, but doesn't care how many more times a call occurs.

I've added this because in some event-driven testing that I'm doing
I cannot always know how many times the event will happen, so
`Times()` is not appropriate, but I need to ensure it gets called,
so `AnyTimes()` is also not appropriate. 