### PR TITLE
Show file and line number of call during errors

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -28,6 +28,7 @@ type Call struct {
 	method   string        // the name of the method
 	args     []Matcher     // the args
 	rets     []interface{} // the return values (if any)
+	origin   string        // file and line number of call setup
 
 	preReqs []*Call // prerequisite calls
 
@@ -78,8 +79,8 @@ func (c *Call) Do(f interface{}) *Call {
 func (c *Call) Return(rets ...interface{}) *Call {
 	mt := c.methodType()
 	if len(rets) != mt.NumOut() {
-		c.t.Fatalf("wrong number of arguments to Return for %T.%v: got %d, want %d",
-			c.receiver, c.method, len(rets), mt.NumOut())
+		c.t.Fatalf("wrong number of arguments to Return for %T.%v: got %d, want %d [%s]",
+			c.receiver, c.method, len(rets), mt.NumOut(), c.origin)
 	}
 	for i, ret := range rets {
 		if got, want := reflect.TypeOf(ret), mt.Out(i); got == want {
@@ -90,8 +91,8 @@ func (c *Call) Return(rets ...interface{}) *Call {
 			case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
 				// ok
 			default:
-				c.t.Fatalf("argument %d to Return for %T.%v is nil, but %v is not nillable",
-					i, c.receiver, c.method, want)
+				c.t.Fatalf("argument %d to Return for %T.%v is nil, but %v is not nillable [%s]",
+					i, c.receiver, c.method, want, c.origin)
 			}
 		} else if got.AssignableTo(want) {
 			// Assignable type relation. Make the assignment now so that the generated code
@@ -100,8 +101,8 @@ func (c *Call) Return(rets ...interface{}) *Call {
 			v.Set(reflect.ValueOf(ret))
 			rets[i] = v.Interface()
 		} else {
-			c.t.Fatalf("wrong type of argument %d to Return for %T.%v: %v is not assignable to %v",
-				i, c.receiver, c.method, got, want)
+			c.t.Fatalf("wrong type of argument %d to Return for %T.%v: %v is not assignable to %v [%s]",
+				i, c.receiver, c.method, got, want, c.origin)
 		}
 	}
 
@@ -124,7 +125,8 @@ func (c *Call) SetArg(n int, value interface{}) *Call {
 	// TODO: This will break on variadic methods.
 	// We will need to check those at invocation time.
 	if n < 0 || n >= mt.NumIn() {
-		c.t.Fatalf("SetArg(%d, ...) called for a method with %d args", n, mt.NumIn())
+		c.t.Fatalf("SetArg(%d, ...) called for a method with %d args [%s]",
+			n, mt.NumIn(), c.origin)
 	}
 	// Permit setting argument through an interface.
 	// In the interface case, we don't (nay, can't) check the type here.
@@ -133,12 +135,14 @@ func (c *Call) SetArg(n int, value interface{}) *Call {
 	case reflect.Ptr:
 		dt := at.Elem()
 		if vt := reflect.TypeOf(value); !vt.AssignableTo(dt) {
-			c.t.Fatalf("SetArg(%d, ...) argument is a %v, not assignable to %v", n, vt, dt)
+			c.t.Fatalf("SetArg(%d, ...) argument is a %v, not assignable to %v [%s]",
+				n, vt, dt, c.origin)
 		}
 	case reflect.Interface:
 		// nothing to do
 	default:
-		c.t.Fatalf("SetArg(%d, ...) referring to argument of non-pointer non-interface type %v", n, at)
+		c.t.Fatalf("SetArg(%d, ...) referring to argument of non-pointer non-interface type %v [%s]",
+			n, at, c.origin)
 	}
 	c.setArgs[n] = reflect.ValueOf(value)
 	return c
@@ -184,7 +188,7 @@ func (c *Call) String() string {
 		args[i] = arg.String()
 	}
 	arguments := strings.Join(args, ", ")
-	return fmt.Sprintf("%T.%v(%s)", c.receiver, c.method, arguments)
+	return fmt.Sprintf("%T.%v(%s) [%s]", c.receiver, c.method, arguments, c.origin)
 }
 
 // Tests if the given call matches the expected call.


### PR DESCRIPTION
Show file and line number of call during errors

This commit makes erroneous calls show their origin. Unexpected calls
show where they happened. Missing calls and improper expectations show
where they were set up in the tests. This information is printed after
each error message in square brackets.

Here is an example of the output:

```
--- FAIL: TestNoMatchingCall (0.00s)
    controller.go:119: no matching expected call: *mocktest_test.MockDoer.Do([hello]) [/home/ooesili/golang/src/github.com/ooesili/mocktest/mocktest.go:8]
--- FAIL: TestWrongReturnArity (0.00s)
    call.go:83: wrong number of arguments to Return for *mocktest_test.MockDoer.Do: got 1, want 2 [/home/ooesili/golang/src/github.com/ooesili/mocktest/mocktest_test.go:23]
    controller.go:164: missing call(s) to *mocktest_test.MockDoer.Do(is equal to blah) [/home/ooesili/golang/src/github.com/ooesili/mocktest/mocktest_test.go:23]
    controller.go:171: aborting test due to missing call(s)
--- FAIL: TestNotNillable (0.00s)
    call.go:95: argument 0 to Return for *mocktest_test.MockDoer.Do is nil, but string is not nillable [/home/ooesili/golang/src/github.com/ooesili/mocktest/mocktest_test.go:31]
    controller.go:164: missing call(s) to *mocktest_test.MockDoer.Do(is equal to blah) [/home/ooesili/golang/src/github.com/ooesili/mocktest/mocktest_test.go:31]
    controller.go:171: aborting test due to missing call(s)
--- FAIL: TestWrongReturnType (0.00s)
    call.go:105: wrong type of argument 1 to Return for *mocktest_test.MockDoer.Do: string is not assignable to error [/home/ooesili/golang/src/github.com/ooesili/mocktest/mocktest_test.go:39]
    controller.go:164: missing call(s) to *mocktest_test.MockDoer.Do(is equal to blah) [/home/ooesili/golang/src/github.com/ooesili/mocktest/mocktest_test.go:39]
    controller.go:171: aborting test due to missing call(s)
FAIL
FAIL    github.com/ooesili/mocktest 0.002s
```

I had a hard time deciding how I wanted the output to look so I'd love some feedback. I originally had the file and line number displayed as a prefix like `mocktest_test.go:14: missing call(s) to ...`, which looks great when used with [Ginkgo](https://onsi.github.com/ginkgo/), but looks awkward with plain `go test`, since the prefixes were doubled `controller.go:164: mocktest_test.go:14: missing call(s) to ...`.

It would be trivial to also add the package/function name of the caller to this output. I decided against that since the file and line number is generally all I'm after when debugging.
