### PR TITLE
Fix package name of parameters in source mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ It supports the following flags:
  *  `-destination`: A file to which to write the resulting source code. If you
     don't set this, the code is printed to standard output.
 
- *  `-package`: The package to use for the resulting mock class
-    source code. If you don't set this, the package name is `mock_` concatenated
-    with the package of the input file.
+ *  `-package`: The package name to use for the resulting mock class source
+    code. If you don't set this, the package name is `mock_` concatenated with
+    the package of the input file.
 
  *  `-imports`: A list of explicit imports that should be used in the resulting
     source code, specified as a comma-separated list of elements of the form
@@ -68,6 +68,13 @@ It supports the following flags:
     specified as a comma-separated list of elements of the form
     `foo=bar/baz.go`, where `bar/baz.go` is the source file and `foo` is the
     package name of that file used by the -source file.
+
+ *  `-self_package`: The package this mock will be part of. Setting this
+    ensures that the package is not included in the imports.
+
+ *  `-source_package`: The package of the types in the source file. Setting
+    this ensures that types referenced by the interfaces in the source file
+    will be properly qualified.
 
 For an example of the use of `mockgen`, see the `sample/` directory. In simple
 cases, you will need only the `-source` flag.


### PR DESCRIPTION
Fix the package name of parameters in source mode so that the types are
properly qualified.

Update README.md to document the new flag, `-source_package`, and to
also document the `-self_package` flag.

I tested this with a simple script:
```sh
#!/bin/sh
go build -o mg ./mockgen

rm -rf ./test
mkdir ./test

printf "====================imp1 reflect===================\n"
./mg -package user github.com/golang/mock/sample/imp1 ForeignEmbedded > test/imp1_reflect.go

printf "====================imp1 source==================\n"
./mg -package user -source_package github.com/golang/mock/sample/imp1 -source ./sample/imp1/imp1.go > test/imp1_source.go

printf "====================sample reflect===================\n"
./mg -package user github.com/golang/mock/sample Index,Embed,Embedded > test/user_reflect.go

printf "====================sample source===================\n"
./mg -package user -imports=io=io,imp1=github.com/golang/mock/mock/sample/imp1,imp_three=github.com/golang/mock/sample/imp3,imp_four=github.com/golang/mock/sample/imp4 -aux_files=imp1=./sample/imp1/imp1.go,imp_three=./sample/imp3/imp3.go,imp_four=./sample/imp4/imp4.go -source ./sample/user.go > test/user_source.go 
```

And then compared the two reflect and source pairs. The sample source of the source/reflect pair has a significant number of differences, but those are mostly due to ordering of source code. The imports aren't exactly the same, though, because source mode still doesn't handle the dot import correctly.