### PR TITLE
fix(model): resolve pointer based types w/ reflect

### DIFF
--- a/mockgen/model/model.go
+++ b/mockgen/model/model.go
@@ -106,9 +106,8 @@ func (m *Method) addImports(im map[string]bool) {
 
 // Parameter is an argument or return parameter of a method.
 type Parameter struct {
-	Name   string // may be empty
-	Prefix string
-	Type   Type
+	Name string // may be empty
+	Type Type
 }
 
 func (p *Parameter) Print(w io.Writer) {


### PR DESCRIPTION
Previously using reflection wouldn't unwrap pointers, arrays, or slices, resulting in `t.Name()` being empty for parameters.

This PR correctly unwraps types to get to their root type and builds a prefix to restore the call signature.
