### PR TITLE
Add StrMatcher in order to enable expecting complex objects.

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -51,6 +51,18 @@ func (e eqMatcher) String() string {
 	return fmt.Sprintf("is equal to %v", e.x)
 }
 
+type strMatcher struct {
+	x interface{}
+}
+
+func (s strMatcher) Matches(x interface{}) bool {
+	return fmt.Sprintf("%v", x) == fmt.Sprintf("%v", s.x)
+}
+
+func (s strMatcher) String() string {
+	return fmt.Sprintf("%v", s.x)
+}
+
 type nilMatcher struct{}
 
 func (nilMatcher) Matches(x interface{}) bool {
@@ -86,9 +98,10 @@ func (n notMatcher) String() string {
 }
 
 // Constructors
-func Any() Matcher             { return anyMatcher{} }
-func Eq(x interface{}) Matcher { return eqMatcher{x} }
-func Nil() Matcher             { return nilMatcher{} }
+func Any() Matcher              { return anyMatcher{} }
+func Eq(x interface{}) Matcher  { return eqMatcher{x} }
+func Str(x interface{}) Matcher { return strMatcher{x} }
+func Nil() Matcher              { return nilMatcher{} }
 func Not(x interface{}) Matcher {
 	if m, ok := x.(Matcher); ok {
 		return notMatcher{m}

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -16,10 +16,12 @@ package gomock_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	mock_matcher "github.com/golang/mock/gomock/mock_matcher"
+	my_gomock "github.com/noibar/mock/gomock"
 )
 
 func TestMatchers(t *testing.T) {
@@ -31,6 +33,7 @@ func TestMatchers(t *testing.T) {
 	tests := []testCase{
 		testCase{gomock.Any(), []e{3, nil, "foo"}, nil},
 		testCase{gomock.Eq(4), []e{4}, []e{3, "blah", nil, int64(4)}},
+		testCase{my_gomock.Str(4), []e{4, "4", int64(4), float64(4.0)}, []e{3, float64(4.1)}},
 		testCase{gomock.Nil(),
 			[]e{nil, (error)(nil), (chan bool)(nil), (*int)(nil)},
 			[]e{"", 0, make(chan bool), errors.New("err"), new(int)}},
@@ -66,5 +69,67 @@ func TestNotMatcher(t *testing.T) {
 	mockMatcher.EXPECT().Matches(5).Return(false)
 	if match := notMatcher.Matches(5); !match {
 		t.Errorf("notMatcher should match 5")
+	}
+}
+
+type testStruct struct {
+	id                string
+	interestingValues []string
+}
+
+func (t testStruct) String() string {
+	return strings.Join(t.interestingValues, ";")
+}
+
+// A more thorough test of strMatcher
+func TestStrMatcher(t *testing.T) {
+	for _, test := range []struct {
+		title    string
+		first    testStruct
+		second   testStruct
+		expected bool
+	}{
+		{
+			title:    "Empty structs",
+			expected: true,
+		}, {
+			title: "Identical structs",
+			first: testStruct{
+				id:                "id",
+				interestingValues: []string{"1", "2", "3"},
+			},
+			second: testStruct{
+				id:                "id",
+				interestingValues: []string{"1", "2", "3"},
+			},
+			expected: true,
+		}, {
+			title: "Identical interesting values",
+			first: testStruct{
+				id:                "first",
+				interestingValues: []string{"1", "2", "3"},
+			},
+			second: testStruct{
+				id:                "second",
+				interestingValues: []string{"1", "2", "3"},
+			},
+			expected: true,
+		}, {
+			title: "Different interesting values",
+			first: testStruct{
+				id:                "first",
+				interestingValues: []string{"1", "2", "3"},
+			},
+			second: testStruct{
+				id:                "second",
+				interestingValues: []string{"1", "2", "3", "4"},
+			},
+			expected: false,
+		},
+	} {
+		matcher := my_gomock.Str(test.first)
+		if match := matcher.Matches(test.second); match != test.expected {
+			t.Errorf("Test %v failed. expected %v, recieved %v", test.title, test.expected, match)
+		}
 	}
 }


### PR DESCRIPTION
StrMatcher can be in use when mock expects a complex object, that we
want to compare only part of his fields. In order to
do so, you have to implement a string method that represent the
interesting fields of the object. For usage example, look in
matchers_test.go:TestStrMatcher.

TODO: change imports to original package in tests.