### PR TITLE
feature: use "Do" return value. Overlap "Return".

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -121,7 +121,7 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 		ctrl.expectedCalls.Remove(preReqCall)
 	}
 
-	rets, action := expected.call(args)
+	action := expected.call(args)
 	if expected.exhausted() {
 		ctrl.expectedCalls.Remove(expected)
 	}
@@ -132,11 +132,8 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	// here we add a deferred Lock to balance it.
 	ctrl.mu.Unlock()
 	defer ctrl.mu.Lock()
-	if action != nil {
-		action()
-	}
 
-	return rets
+	return action()
 }
 
 func (ctrl *Controller) Finish() {


### PR DESCRIPTION
Sometimes need to return a different value for different input arguments. I think it would be more convenient.

Example:

```
func TestRead(t *testing.T) {
    mockCtrl := gomock.NewController(t)
    defer mockCtrl.Finish()
    mockObj := mock_io.NewMockReadWriteCloser(mockCtrl)
    do := func(d []byte) (int, error) {
        return len(d), nil
    }
    mockObj.EXPECT().Read(gomock.Any()).AnyTimes().Do(do)
    fmt.Println(mockObj.Read([]byte{0x1}))
    fmt.Println(mockObj.Read([]byte{0x1, 0x1, 0x1}))
}
```

```
1 <nil>
3 <nil>
```
