### PR TITLE
Add method Invoke  to type Call

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -81,7 +81,6 @@ func (c *Call) Do(f interface{}) *Call {
 
 func (c *Call) Invoke(f interface{}) *Call {
 	// TODO: Check arity and types here, rather than dying badly elsewhere.
-	c.doFunc = reflect.ValueOf(f)
 	funcValue := reflect.ValueOf(f)
 	funcType := funcValue.Type()
 
@@ -276,7 +275,7 @@ func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
 	rets = c.rets
 
 	if c.invokeFunc.IsValid() {
-		rets = make([]interface{}, len(args))
+		rets = make([]interface{}, len(c.retsType))
 		invokeArgs := make([]reflect.Value, len(args))
 		for i := 0; i < len(args); i++ {
 			if args[i] != nil {
@@ -286,6 +285,7 @@ func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
 			}
 		}
 		retValues := c.invokeFunc.Call(invokeArgs)
+		//c.t.Errorf("len(retValues)=%v\n", len(retValues))
 		for i := 0; i < len(c.retsType); i++ {
 			rets[i] = retValues[i].Interface()
 		}

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -151,7 +151,9 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 		ctrl.expectedCalls.Remove(preReqCall)
 	}
 
+	//ctrl.t.Errorf("before expected.call")
 	rets, action := expected.call(args)
+	//ctrl.t.Errorf("after expected.call")
 	if expected.exhausted() {
 		ctrl.expectedCalls.Remove(expected)
 	}

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -55,7 +55,10 @@
 //	- Handle different argument/return types (e.g. ..., chan, map, interface).
 package gomock
 
-import "sync"
+import (
+	"reflect"
+	"sync"
+)
 
 // A TestReporter is something that can be used to report test failures.
 // It is satisfied by the standard library's *testing.T.
@@ -82,6 +85,24 @@ func NewController(t TestReporter) *Controller {
 
 func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...interface{}) *Call {
 	// TODO: check arity, types.
+	receiverType := reflect.TypeOf(receiver)
+	methodObject, exists := receiverType.MethodByName(method)
+	if !exists {
+		ctrl.t.Fatalf("%v has no method named '%v'", receiverType.Name(), method)
+	}
+
+	methodType := methodObject.Func.Type()
+	argsType := []reflect.Type{}
+	retsType := []reflect.Type{}
+
+	for i := 1; i < methodType.NumIn(); i++ {
+		argsType = append(argsType, methodType.In(i))
+	}
+
+	for i := 0; i < methodType.NumOut(); i++ {
+		retsType = append(retsType, methodType.Out(i))
+	}
+
 	margs := make([]Matcher, len(args))
 	for i, arg := range args {
 		if m, ok := arg.(Matcher); ok {
@@ -98,7 +119,16 @@ func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
-	call := &Call{t: ctrl.t, receiver: receiver, method: method, args: margs, minCalls: 1, maxCalls: 1}
+	call := &Call{
+		t:        ctrl.t,
+		receiver: receiver,
+		method:   method,
+		args:     margs,
+		minCalls: 1,
+		maxCalls: 1,
+		argsType: argsType,
+		retsType: retsType,
+	}
 
 	ctrl.expectedCalls.Add(call)
 	return call

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -423,9 +423,9 @@ func TestCallAfterLoopPanic(t *testing.T) {
 
 	subject := new(Subject)
 
-	firstCall := ctrl.RecordCall(subject, "Foo", "1")
-	secondCall := ctrl.RecordCall(subject, "Foo", "2")
-	thirdCall := ctrl.RecordCall(subject, "Foo", "3")
+	firstCall := ctrl.RecordCall(subject, "FooMethod", "1")
+	secondCall := ctrl.RecordCall(subject, "FooMethod", "2")
+	thirdCall := ctrl.RecordCall(subject, "FooMethod", "3")
 
 	gomock.InOrder(firstCall, secondCall, thirdCall)
 

--- a/sample/invoke_user_test.go
+++ b/sample/invoke_user_test.go
@@ -1,0 +1,273 @@
+package user
+
+import (
+	"bufio"
+	"bytes"
+	"code.google.com/p/gomock/sample"
+	"fmt"
+	"github.com/golang/mock/gomock"
+	"github.com/golang/mock/sample/imp1"
+	mock_user "github.com/golang/mock/sample/mock_user"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type TestIndexSuite struct {
+	*gomock.Controller
+	*mock_user.MockIndex
+}
+
+func SetUpTest(t *testing.T) *TestIndexSuite {
+	suite := &TestIndexSuite{}
+	suite.Controller = gomock.NewController(t)
+	suite.MockIndex = mock_user.NewMockIndex(suite.Controller)
+	return suite
+}
+
+func (suite *TestIndexSuite) TearDownTest(t *testing.T) {
+	suite.Finish()
+}
+
+func TestInvoke1(t *testing.T) {
+
+	suite := SetUpTest(t)
+	defer suite.TearDownTest(t)
+	underlying := map[string]interface{}{}
+	putFunc := func(key string, value interface{}) {
+		underlying[key] = value
+	}
+
+	getFunc := func(key string) interface{} {
+		if value, ok := underlying[key]; ok {
+			return value
+		} else {
+			return nil
+		}
+	}
+
+	getTwoFunc := func(key1, key2 string) (interface{}, interface{}) {
+		return getFunc(key1), getFunc(key2)
+	}
+
+	suite.EXPECT().Put(gomock.Any(), gomock.Any()).Invoke(putFunc).AnyTimes()
+	suite.EXPECT().Get(gomock.Any()).Invoke(getFunc).AnyTimes()
+	suite.EXPECT().GetTwo(gomock.Any(), gomock.Any()).Invoke(getTwoFunc).AnyTimes()
+
+	var value, value2 interface{}
+	value = suite.Get("one")
+	assert.Equal(t, value, nil)
+	suite.Put("one", 1)
+	value = suite.Get("one")
+	assert.NotEqual(t, value, nil)
+	assert.Equal(t, value.(int), 1)
+
+	value, value2 = suite.GetTwo("one", "two")
+	assert.Equal(t, value.(int), 1)
+	assert.Equal(t, value2, nil)
+
+	suite.Put("two", 2)
+	value, value2 = suite.GetTwo("one", "two")
+	assert.Equal(t, value.(int), 1)
+	assert.Equal(t, value2, 2)
+
+}
+
+func TestInvokeNillableRet(t *testing.T) {
+	suite := SetUpTest(t)
+	defer suite.TearDownTest(t)
+	suite.EXPECT().NillableRet().Invoke(
+		func() error { return nil },
+	)
+	suite.EXPECT().NillableRet().Invoke(
+		func() error { return fmt.Errorf("Error") },
+	)
+	var err error
+	err = suite.NillableRet()
+	assert.Equal(t, err, nil)
+	err = suite.NillableRet()
+	assert.NotEqual(t, err, nil)
+}
+
+func TestConcreteRet(t *testing.T) {
+	suite := SetUpTest(t)
+	defer suite.TearDownTest(t)
+	suite.EXPECT().ConcreteRet().Invoke(
+		func() chan<- bool { return nil },
+	)
+	suite.EXPECT().ConcreteRet().Invoke(
+		func() chan<- bool { return make(chan<- bool, 1) },
+	)
+	ch := suite.ConcreteRet()
+	//t.Errorf("ch=%+v\n",ch)
+	assert.Equal(t, true, ch == nil)
+	ch = suite.ConcreteRet()
+	assert.NotEqual(t, ch, nil)
+}
+
+func TestEllip(t *testing.T) {
+	suite := SetUpTest(t)
+	defer suite.TearDownTest(t)
+	var result string
+	processor := func(s string, args ...interface{}) {
+		sum := 0
+		for i := 0; i < len(args); i++ {
+			sum += args[i].(int)
+		}
+		result = fmt.Sprintf(s, sum)
+	}
+	processor2 := func(args ...string) {
+		if len(args) == 0 {
+			result = "none"
+		} else {
+			result = ""
+			for i := 0; i < len(args); i++ {
+				result += args[i]
+			}
+		}
+	}
+	suite.EXPECT().Ellip("%d", 0, 1, 1, 2, 3).Invoke(processor)
+	tri := []interface{}{1, 3, 6, 10, 15}
+	suite.EXPECT().Ellip("%d", tri...).Invoke(processor)
+
+	suite.EXPECT().EllipOnly("%d", "5", "6", "7").Invoke(processor2)
+	suite.EXPECT().EllipOnly().Invoke(processor2)
+
+	suite.Ellip("%d", 0, 1, 1, 2, 3)
+	assert.Equal(t, result, "7")
+	suite.Ellip("%d", 1, 3, 6, 10, 15)
+	assert.Equal(t, result, "35")
+
+	suite.EllipOnly("%d", "5", "6", "7")
+	assert.Equal(t, result, "%d567")
+	suite.EllipOnly()
+	assert.Equal(t, result, "none")
+}
+
+func TestRememberInvoke(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIndex := mock_user.NewMockIndex(ctrl)
+
+	kv := map[string]interface{}{}
+	putFunc := func(key string, value interface{}) {
+		kv[key] = value
+	}
+
+	//getFunc := func(key string)interface{} {
+	//	if value, ok := kv[key];ok {
+	//		return value
+	//	}else {
+	//		return nil
+	//	}
+	//}
+
+	//getTwoFunc := func(key1, key2 string)(interface{},interface{}) {
+	//	return getFunc(key1), getFunc(key2)
+	//}
+	mockIndex.EXPECT().Put("a", 1).Invoke(putFunc)            // literals work
+	mockIndex.EXPECT().Put("b", gomock.Eq(2)).Invoke(putFunc) // matchers work too
+
+	// NillableRet returns error. Not declaring it should result in a nil return.
+	mockIndex.EXPECT().NillableRet().Invoke(func() error { return nil })
+	// Calls that returns something assignable to the return type.
+	boolc := make(chan bool)
+	// In this case, "chan bool" is assignable to "chan<- bool".
+	mockIndex.EXPECT().ConcreteRet().Invoke(func() chan<- bool { return boolc })
+	// In this case, nil is assignable to "chan<- bool".
+	mockIndex.EXPECT().ConcreteRet().Invoke(func() chan<- bool { return nil })
+
+	// Should be able to place expectations on variadic methods.
+	mockIndex.EXPECT().Ellip("%d", 0, 1, 1, 2, 3).Invoke(
+		func(fmt string, args ...interface{}) {
+		},
+	) // direct args
+	tri := []interface{}{1, 3, 6, 10, 15}
+	mockIndex.EXPECT().Ellip("%d", tri...).Invoke(
+		func(fmt string, args ...interface{}) {
+		},
+	) // args from slice
+	mockIndex.EXPECT().EllipOnly(gomock.Eq("arg")).Invoke(
+		func(...string) {},
+	)
+
+	user.Remember(mockIndex, []string{"a", "b"}, []interface{}{1, 2})
+	// Check the ConcreteRet calls.
+	if c := mockIndex.ConcreteRet(); c != boolc {
+		t.Errorf("ConcreteRet: got %v, want %v", c, boolc)
+	}
+	if c := mockIndex.ConcreteRet(); c != nil {
+		t.Errorf("ConcreteRet: got %v, want nil", c)
+	}
+
+	// Try one with an action.
+	calledString := ""
+	mockIndex.EXPECT().Put(gomock.Any(), gomock.Any()).Invoke(func(key string, _ interface{}) {
+		calledString = key
+	})
+	mockIndex.EXPECT().NillableRet().Invoke(func() error { return nil })
+	user.Remember(mockIndex, []string{"blah"}, []interface{}{7})
+	if calledString != "blah" {
+		t.Fatalf(`Uh oh. %q != "blah"`, calledString)
+	}
+
+	// Use Do with a nil arg.
+	mockIndex.EXPECT().Put("nil-key", gomock.Any()).Invoke(func(key string, value interface{}) {
+		if value != nil {
+			t.Errorf("Put did not pass through nil; got %v", value)
+		}
+	})
+	mockIndex.EXPECT().NillableRet().Invoke(func() error { return nil })
+	user.Remember(mockIndex, []string{"nil-key"}, []interface{}{nil})
+}
+
+func TestGrabPointerInvoke(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIndex := mock_user.NewMockIndex(ctrl)
+	mockIndex.EXPECT().Ptr(gomock.Any()).Invoke(func(arg *int) { *arg = 7 })
+
+	i := user.GrabPointer(mockIndex)
+	if i != 7 {
+		t.Errorf("Expected 7, got %d", i)
+	}
+}
+func TestEmbeddedInterface(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEmbed := mock_user.NewMockEmbed(ctrl)
+	var msg string
+	mockEmbed.EXPECT().RegularMethod().Invoke(func() { msg = "RegularMethod" })
+	mockEmbed.EXPECT().EmbeddedMethod().Invoke(func() { msg = "EmbededMethod" })
+	mockEmbed.EXPECT().ForeignEmbeddedMethod().Invoke(
+		func() *bufio.Reader {
+			buf := bytes.NewBuffer([]byte{})
+			writer := bufio.NewWriter(buf)
+			writer.WriteString("ForeignEmbeddedMethod\n")
+			writer.Flush()
+			return bufio.NewReader(buf)
+		},
+	)
+
+	mockEmbed.RegularMethod()
+	assert.Equal(t, msg, "RegularMethod")
+	mockEmbed.EmbeddedMethod()
+	assert.Equal(t, msg, "EmbededMethod")
+	var emb imp1.ForeignEmbedded = mockEmbed // also does interface check
+	reader := emb.ForeignEmbeddedMethod()
+	s, err := reader.ReadString('\n')
+	assert.Equal(t, err, nil)
+	assert.Equal(t, s, "ForeignEmbeddedMethod\n")
+}
+func TestExpectTrueNilInvoke(t *testing.T) {
+	// Make sure that passing "nil" to EXPECT (thus as a nil interface value),
+	// will correctly match a nil concrete type.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIndex := mock_user.NewMockIndex(ctrl)
+	mockIndex.EXPECT().Ptr(nil).Invoke(func(*int) {}) // this nil is a nil interface{}
+	mockIndex.Ptr(nil)                                // this nil is a nil *int
+}


### PR DESCRIPTION
Although Call.Do can be used to register a doFunc,  however,   doFunc has several flaws:

1. doFunc can has different return types in contrast to the target function.
2. doFunc has no influence on return values of mocked function.
3. closure can be employed to make mocked function return the same values as doFunc, but it's so tricky and nonintuitive.

so another method Invoke is need,  Call.Invoke can be used to register a InvokeFunc which has features as follows:

1. InvokeFunc has the same return types as the target function(receiver type not included).
2. mocked function return the same values  as Invoke.

e.g.

``` go
func TestFoobar(t *testing.T) {
	ctrl := gomock.NewController(t)
	foobar := mock_gomockdo.NewMockFoobar(ctrl)
		foobar.EXPECT().DoAnyThing(gomock.Any(), gomock.Any()).Invoke(
			func(x, y int) int{
				return x+y
			},
		).AnyTimes()

	for i := 0; i <10; i++ {
		a := foobar.DoAnyThing(1, i)
		fmt.Printf("i=%v, a=%+v\n",i, a)
	}
}
```
