### PR TITLE
Fix Do method for variadic functions

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -223,7 +223,7 @@ func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
 	if c.doFunc.IsValid() {
 		doArgs := make([]reflect.Value, len(args))
 		ft := c.doFunc.Type()
-		for i := 0; i < ft.NumIn(); i++ {
+		for i := 0; i < len(args); i++ {
 			if args[i] != nil {
 				doArgs[i] = reflect.ValueOf(args[i])
 			} else {

--- a/sample/user_test.go
+++ b/sample/user_test.go
@@ -63,6 +63,25 @@ func TestRemember(t *testing.T) {
 	user.Remember(mockIndex, []string{"nil-key"}, []interface{}{nil})
 }
 
+func TestVariadicFunction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockIndex := mock_user.NewMockIndex(ctrl)
+	m := mockIndex.EXPECT().Ellip("%d", 0, 1, 1, 2, 3)
+	m.Do(func(format string, nums ...int) {
+		sum := 0
+		for _, value := range nums {
+			sum += value
+		}
+		if sum != 7 {
+			t.Errorf("Expected 7, got %d", sum)
+		}
+	})
+
+	mockIndex.Ellip("%d", 0, 1, 1, 2, 3)
+}
+
 func TestGrabPointer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Without this fix, using the `Do` method on a variadic function will cause a panic, because not all of the arguments will be propagated to the action function:

```
$ go test ./sample
--- FAIL: TestVariadicFunction (0.00s)
panic: reflect: Call using zero Value argument [recovered]
	panic: reflect: Call using zero Value argument [recovered]
	panic: reflect: Call using zero Value argument
...
github.com/golang/mock/gomock.(*Controller).Finish(0xc4200d57a0)
	/gopath/src/github.com/golang/mock/gomock/controller.go:149 +0x320
...
github.com/golang/mock/gomock.(*Call).call.func1()
	/gopath/src/github.com/golang/mock/gomock/call.go:234 +0x6a
...
FAIL	github.com/golang/mock/sample	0.013s
```

Cc: @iderdik, @chr0n1x