### PR TITLE
Added usage statement when called with wrong number of arguments (Fixes #69)

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -58,6 +58,7 @@ func main() {
 		pkg, err = ParseFile(*source)
 	} else {
 		if flag.NArg() != 2 {
+			usage()
 			log.Fatal("Expected exactly two arguments")
 		}
 		pkg, err = Reflect(flag.Arg(0), strings.Split(flag.Arg(1), ","))


### PR DESCRIPTION
This is a one line change that fixes #69.

Now when mockgen is invoked with no arguments the usage statement is printed.