### PR TITLE
Fix call for variable arguments method

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -222,14 +222,8 @@ func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
 	// Actions
 	if c.doFunc.IsValid() {
 		doArgs := make([]reflect.Value, len(args))
-		ft := c.doFunc.Type()
-		for i := 0; i < ft.NumIn() || i < len(args); i++ {
-			if args[i] != nil {
-				doArgs[i] = reflect.ValueOf(args[i])
-			} else {
-				// Use the zero value for the arg.
-				doArgs[i] = reflect.Zero(ft.In(i))
-			}
+		for i := range args {
+			doArgs[i] = reflect.ValueOf(args[i])
 		}
 		action = func() { c.doFunc.Call(doArgs) }
 	}

--- a/gomock/call.go
+++ b/gomock/call.go
@@ -223,7 +223,7 @@ func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
 	if c.doFunc.IsValid() {
 		doArgs := make([]reflect.Value, len(args))
 		ft := c.doFunc.Type()
-		for i := 0; i < ft.NumIn(); i++ {
+		for i := 0; i < ft.NumIn() || i < len(args); i++ {
 			if args[i] != nil {
 				doArgs[i] = reflect.ValueOf(args[i])
 			} else {

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -119,6 +119,10 @@ func (s *Subject) BarMethod(arg string) int {
 	return 0
 }
 
+func (s *Subject) VariableArgmentsMethod(args ...string) int {
+	return 0
+}
+
 func assertEqual(t *testing.T, expected interface{}, actual interface{}) {
 	if !reflect.DeepEqual(expected, actual) {
 		t.Error("Expected %+v, but got %+v", expected, actual)
@@ -312,6 +316,39 @@ func TestDo(t *testing.T) {
 	}
 	if "argument" != argument {
 		t.Error("Do callback received wrong argument.")
+	}
+
+	ctrl.Finish()
+}
+
+func TestDoWithVariableArguments(t *testing.T) {
+	_, ctrl := createFixtures(t)
+	subject := new(Subject)
+
+	doCalled := false
+	var arguments []string
+	ctrl.RecordCall(subject, "VariableArgmentsMethod", "argument1", "argument2").Do(
+		func(args ...string) {
+			doCalled = true
+			arguments = args
+		})
+	if doCalled {
+		t.Error("Do() callback called too early.")
+	}
+
+	ctrl.Call(subject, "VariableArgmentsMethod", "argument1", "argument2")
+
+	if !doCalled {
+		t.Error("Do() callback not called.")
+	}
+	if !reflect.DeepEqual(
+		[]string{
+			"argument1",
+			"argument2",
+		},
+		arguments,
+	) {
+		t.Error("Do callback received wrong arguments.")
 	}
 
 	ctrl.Finish()


### PR DESCRIPTION
When executing `Do` with variable arguments, panic because `reflect.Type.NumIn()` of func count variable arguments to `1` .

```
--- FAIL: TestDoWithVariableArguments (0.00s)
panic: reflect: Call using zero Value argument [recovered]
        panic: reflect: Call using zero Value argument
```