### PR TITLE
add time matcher

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -17,6 +17,7 @@ package gomock
 import (
 	"fmt"
 	"reflect"
+	"time"
 )
 
 // A Matcher is a representation of a class of values.
@@ -49,6 +50,22 @@ func (e eqMatcher) Matches(x interface{}) bool {
 
 func (e eqMatcher) String() string {
 	return fmt.Sprintf("is equal to %v", e.x)
+}
+
+type timeMatcher struct {
+	t time.Time
+}
+
+func (t timeMatcher) Matches(x interface{}) bool {
+	converted, ok := x.(time.Time)
+	if !ok {
+		return false
+	}
+	return t.t.Equal(converted)
+}
+
+func (t timeMatcher) String() string {
+	return fmt.Sprintf("is equal to %v", t.t)
 }
 
 type nilMatcher struct{}
@@ -86,9 +103,10 @@ func (n notMatcher) String() string {
 }
 
 // Constructors
-func Any() Matcher             { return anyMatcher{} }
-func Eq(x interface{}) Matcher { return eqMatcher{x} }
-func Nil() Matcher             { return nilMatcher{} }
+func Any() Matcher               { return anyMatcher{} }
+func Eq(x interface{}) Matcher   { return eqMatcher{x} }
+func TimeEq(t time.Time) Matcher { return timeMatcher{t} }
+func Nil() Matcher               { return nilMatcher{} }
 func Not(x interface{}) Matcher {
 	if m, ok := x.(Matcher); ok {
 		return notMatcher{m}

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mock_matcher "github.com/golang/mock/gomock/mock_matcher"
+	"time"
 )
 
 func TestMatchers(t *testing.T) {
+	testTime := time.Now()
 	type e interface{}
 	type testCase struct {
 		matcher gomock.Matcher
@@ -31,6 +33,7 @@ func TestMatchers(t *testing.T) {
 	tests := []testCase{
 		testCase{gomock.Any(), []e{3, nil, "foo"}, nil},
 		testCase{gomock.Eq(4), []e{4}, []e{3, "blah", nil, int64(4)}},
+		testCase{gomock.TimeEq(testTime), []e{testTime}, []e{testTime.Add(time.Second)}},
 		testCase{gomock.Nil(),
 			[]e{nil, (error)(nil), (chan bool)(nil), (*int)(nil)},
 			[]e{"", 0, make(chan bool), errors.New("err"), new(int)}},


### PR DESCRIPTION
Times can't be compared using a regular `==`, the `time.Equal` function needs to be used (see https://golang.org/pkg/time/#Time.Equal). I propose we add a special matcher just for `time.Time` values.