### PR TITLE
Build flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ It supports the following flags:
     `foo=bar/baz.go`, where `bar/baz.go` is the source file and `foo` is the
     package name of that file used by the -source file.
 
+*  `-build_flags`: (reflect mode only ) Flags passed verbatim to `go build`.
+
 For an example of the use of `mockgen`, see the `sample/` directory. In simple
 cases, you will need only the `-source` flag.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ It supports the following flags:
     `foo=bar/baz.go`, where `bar/baz.go` is the source file and `foo` is the
     package name of that file used by the -source file.
 
-*  `-build_flags`: (reflect mode only ) Flags passed verbatim to `go build`.
+*  `-build_flags`: (reflect mode only) Flags passed verbatim to `go build`.
 
 For an example of the use of `mockgen`, see the `sample/` directory. In simple
 cases, you will need only the `-source` flag.

--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -34,6 +34,7 @@ import (
 var (
 	progOnly = flag.Bool("prog_only", false, "(reflect mode) Only generate the reflection program; write it to stdout.")
 	execOnly = flag.String("exec_only", "", "(reflect mode) If set, execute this reflection program.")
+	buildFlags = flag.String("build_flags", "", "(reflect mode) Additional flags for go build.")
 )
 
 func Reflect(importPath string, symbols []string) (*model.Package, error) {
@@ -72,7 +73,7 @@ func Reflect(importPath string, symbols []string) (*model.Package, error) {
 		}
 
 		// Build the program.
-		cmd := exec.Command("go", "build", "-o", progBinary, progSource)
+		cmd := exec.Command("go", "build", *buildFlags, "-o", progBinary, progSource)
 		cmd.Dir = tmpDir
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
Adds the ability to pass additional flags to `go build`. Fixes #76.