### PR TITLE
Add travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  # go 1.4 is the first version to support "go generate"
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
+  - 1.8
+
+script:
+  - go build ./...
+  - go install github.com/golang/mock/mockgen
+  - ./check_go_fmt.sh
+  - ./check_go_generate.sh
+  - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+gomock [![Build Status](https://travis-ci.org/golang/mock.svg?branch=master)](https://travis-ci.org/golang/mock)
+======
+
 GoMock is a mocking framework for the [Go programming language][golang]. It
 integrates well with Go's built-in `testing` package, but can be used in other
 contexts too.

--- a/check_go_fmt.sh
+++ b/check_go_fmt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This script is used by the CI to check if the code is gofmt formatted.
+
+set -euo pipefail
+cd "$( dirname "$0" )"
+
+GOFMT_DIFF=$( gofmt -d $( IFS='\n'; find . -type f -name '*.go' ) )
+if [[ -n "${GOFMT_DIFF}" ]]; then
+    echo "${GOFMT_DIFF}"
+    echo
+    echo "The go source files aren't gofmt formatted."
+    exit 1
+fi

--- a/check_go_generate.sh
+++ b/check_go_generate.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This script is used by the CI to check if 'go generate ./...' is up to date.
+#
+# Note: If the generated files aren't up to date then this script updates
+# them despite printing an error message so running it the second time
+# might not print any errors. This isn't very useful locally during development
+# but it works well with the CI that downloads a fresh version of the repo
+# each time before executing this script.
+
+set -euo pipefail
+cd "$( dirname "$0" )"
+
+TEMP_DIR=$( mktemp -d )
+function cleanup() {
+    rm -rf "${TEMP_DIR}"
+}
+trap cleanup EXIT
+
+cp -r . "${TEMP_DIR}/"
+go generate ./...
+if ! diff -r . "${TEMP_DIR}"; then
+    echo
+    echo "The generated files aren't up to date."
+    echo "Update them with the 'go generate ./...' command."
+    exit 1
+fi

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -1,3 +1,5 @@
+//go:generate mockgen -destination mock_matcher/mock_matcher.go github.com/golang/mock/gomock Matcher
+
 // Copyright 2010 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/sample/user.go
+++ b/sample/user.go
@@ -1,3 +1,5 @@
+//go:generate mockgen -destination mock_user/mock_user.go github.com/golang/mock/sample Index,Embed,Embedded
+
 // An example package with an interface.
 package user
 

--- a/update_mocks.sh
+++ b/update_mocks.sh
@@ -1,9 +1,0 @@
-#! /bin/bash -e
-
-mockgen github.com/golang/mock/gomock Matcher \
-  > gomock/mock_matcher/mock_matcher.go
-mockgen github.com/golang/mock/sample Index,Embed,Embedded \
-  > sample/mock_user/mock_user.go
-gofmt -w gomock/mock_matcher/mock_matcher.go sample/mock_user/mock_user.go
-
-echo >&2 "OK"


### PR DESCRIPTION
### Description

This change adds a travis-ci (https://travis-ci.org) config that can be used to perform various checks before allowing PRs to be merged into master. This could be a nice addition to the tests written for #81.

The CI setup performs the following checks with several golang versions:
- Sources can be built
- Sources are formatted with `gofmt`
- Generated files are up to date (`go generate ./...`)
- Go tests are passing

### TODOs after merging this

The `github.com/golang` account has to sign in to https://travis-ci.org (with github) and after clicking the `<top-right-profile-icon> | Accounts` menu the switch on the left side of the `golang/mock` repo should be turned on.

On github go to the github.com/golang/mock repo, click `Settings | Branches | Protected branches`. Protect the master branch. After protecting it enable the `Require status checks to pass before merging` checkbox - this should make the travis-ci checkbox visible - and as a last step enable the travis-ci check by ticking its checkbox. This setting will make the travis-ci build status available on the github PR pages.

Travis-ci is free to use with open source projects. I don't know whether registering to github.com/golang account with travis-ci is a problem (legal or other...).