### PR TITLE
Detect adding 'self' as a prereq in Call.After

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -156,12 +156,11 @@ func (c *Call) isPreReq(other *Call) bool {
 
 // After declares that the call may only match after preReq has been exhausted.
 func (c *Call) After(preReq *Call) *Call {
+	if c == preReq {
+		c.t.Fatalf("A call isn't allowed to be it's own prerequisite")
+	}
 	if preReq.isPreReq(c) {
-		msg := fmt.Sprintf(
-			"Loop in call order: %v is a prerequisite to %v (possibly indirectly).",
-			c, preReq,
-		)
-		panic(msg)
+		c.t.Fatalf("Loop in call order: %v is a prerequisite to %v (possibly indirectly).", c, preReq)
 	}
 
 	c.preReqs = append(c.preReqs, preReq)

--- a/gomock/call_test.go
+++ b/gomock/call_test.go
@@ -1,0 +1,47 @@
+package gomock
+
+import "testing"
+
+type mockTestReporter struct {
+	errorCalls int
+	fatalCalls int
+}
+
+func (o *mockTestReporter) Errorf(format string, args ...interface{}) {
+	o.errorCalls++
+}
+
+func (o *mockTestReporter) Fatalf(format string, args ...interface{}) {
+	o.fatalCalls++
+}
+
+func TestCall_After(t *testing.T) {
+	t.Run("SelfPrereqCallsFatalf", func(t *testing.T) {
+		tr1 := &mockTestReporter{}
+
+		c := &Call{t: tr1}
+		c.After(c)
+
+		if tr1.fatalCalls != 1 {
+			t.Errorf("number of fatal calls == %v, want 1", tr1.fatalCalls)
+		}
+	})
+
+	t.Run("LoopInCallOrderCallsFatalf", func(t *testing.T) {
+		tr1 := &mockTestReporter{}
+		tr2 := &mockTestReporter{}
+
+		c1 := &Call{t: tr1}
+		c2 := &Call{t: tr2}
+		c1.After(c2)
+		c2.After(c1)
+
+		if tr1.errorCalls != 0 || tr1.fatalCalls != 0 {
+			t.Error("unexpected errors")
+		}
+
+		if tr2.fatalCalls != 1 {
+			t.Errorf("number of fatal calls == %v, want 1", tr2.fatalCalls)
+		}
+	})
+}


### PR DESCRIPTION
- Adding a `Call` as its own prerequisite will panic (in `Call.After`)
- Written some tests for `Call.After`

Fixes #84 