### PR TITLE
Return verbose errors why expected method call did not match

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -163,7 +163,7 @@ func (c *Call) isPreReq(other *Call) bool {
 // After declares that the call may only match after preReq has been exhausted.
 func (c *Call) After(preReq *Call) *Call {
 	if c == preReq {
-		c.t.Fatalf("A call isn't allowed to be it's own prerequisite")
+		c.t.Fatalf("A call isn't allowed to be its own prerequisite")
 	}
 	if preReq.isPreReq(c) {
 		c.t.Fatalf("Loop in call order: %v is a prerequisite to %v (possibly indirectly).", c, preReq)
@@ -196,20 +196,21 @@ func (c *Call) String() string {
 // If yes, returns nil. If no, returns error with message explaining why it does not match.
 func (c *Call) matches(args []interface{}) error {
 	if len(args) != len(c.args) {
-		return fmt.Errorf("Invalid number of arguments of call: %s. Set: %s, while this call takes: %s",
+		return fmt.Errorf("Expected call at %s has the wrong number of arguments. Got: %s, want: %s",
 			c.origin, strconv.Itoa(len(args)), strconv.Itoa(len(c.args)))
 	}
 	for i, m := range c.args {
 		if !m.Matches(args[i]) {
-			return fmt.Errorf("The expected argument of index: %s of this call: %s did not match the actual argument.\nActual argument: %s, expected: %v\n",
-				strconv.Itoa(i), c.origin, m, args[i])
+			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v\n",
+				c.origin, strconv.Itoa(i), args[i], m)
 		}
 	}
 
 	// Check that all prerequisite calls have been satisfied.
 	for _, preReqCall := range c.preReqs {
 		if !preReqCall.satisfied() {
-			return fmt.Errorf("A prerequisite call was not satisfied:\n%v\nshould be called before:\n%v", preReqCall, c)
+			return fmt.Errorf("Expected call at %s doesn't have a prerequisite call satisfied:\n%v\nshould be called before:\n%v",
+				c.origin, preReqCall, c)
 		}
 	}
 

--- a/gomock/call.go
+++ b/gomock/call.go
@@ -189,7 +189,7 @@ func (c *Call) String() string {
 		args[i] = arg.String()
 	}
 	arguments := strings.Join(args, ", ")
-	return fmt.Sprintf("%T.%v(%s) [%s]", c.receiver, c.method, arguments, c.origin)
+	return fmt.Sprintf("%T.%v(%s) %s", c.receiver, c.method, arguments, c.origin)
 }
 
 // Tests if the given call matches the expected call.

--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -14,6 +14,11 @@
 
 package gomock
 
+import (
+	"errors"
+	"fmt"
+)
+
 // callSet represents a set of expected calls, indexed by receiver and method
 // name.
 type callSet map[interface{}]map[string][]*Call
@@ -47,19 +52,20 @@ func (cs callSet) Remove(call *Call) {
 	}
 }
 
-// FindMatch searches for a matching call. Returns nil if no call matched.
-func (cs callSet) FindMatch(receiver interface{}, method string, args []interface{}) *Call {
+// FindMatch searches for a matching call. Returns error with explanation message if no call matched.
+func (cs callSet) FindMatch(receiver interface{}, method string, args []interface{}) (*Call, error) {
 	methodMap, ok := cs[receiver]
 	if !ok {
-		return nil
+		return nil, errors.New("No expected method calls for that receiver")
 	}
 	calls, ok := methodMap[method]
 	if !ok {
-		return nil
+		return nil, fmt.Errorf("No expected calls of the method: %s for that receiver", method)
 	}
 
 	// Search through the unordered set of calls expected on a method on a
 	// receiver.
+	callsErrors := ""
 	for _, call := range calls {
 		// A call should not normally still be here if exhausted,
 		// but it can happen if, for instance, .Times(0) was used.
@@ -67,10 +73,13 @@ func (cs callSet) FindMatch(receiver interface{}, method string, args []interfac
 		if call.exhausted() {
 			continue
 		}
-		if call.matches(args) {
-			return call
+		err := call.matches(args)
+		if err != nil {
+			callsErrors += "\n" + err.Error()
+		} else {
+			return call, nil
 		}
 	}
 
-	return nil
+	return nil, fmt.Errorf(callsErrors)
 }

--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -56,11 +56,11 @@ func (cs callSet) Remove(call *Call) {
 func (cs callSet) FindMatch(receiver interface{}, method string, args []interface{}) (*Call, error) {
 	methodMap, ok := cs[receiver]
 	if !ok {
-		return nil, errors.New("No expected method calls for that receiver")
+		return nil, errors.New("there are no expected method calls for that receiver")
 	}
 	calls, ok := methodMap[method]
 	if !ok {
-		return nil, fmt.Errorf("No expected calls of the method: %s for that receiver", method)
+		return nil, fmt.Errorf("there are no expected calls of the method: %s for that receiver", method)
 	}
 
 	// Search through the unordered set of calls expected on a method on a
@@ -71,6 +71,7 @@ func (cs callSet) FindMatch(receiver interface{}, method string, args []interfac
 		// but it can happen if, for instance, .Times(0) was used.
 		// Pretend the call doesn't match.
 		if call.exhausted() {
+			callsErrors += "\nThe call was exhausted."
 			continue
 		}
 		err := call.matches(args)

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -126,10 +126,10 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
-	expected := ctrl.expectedCalls.FindMatch(receiver, method, args)
-	if expected == nil {
+	expected, err := ctrl.expectedCalls.FindMatch(receiver, method, args)
+	if err != nil {
 		origin := callerInfo(2)
-		ctrl.t.Fatalf("no matching expected call: %T.%v(%v) [%s]", receiver, method, args, origin)
+		ctrl.t.Fatalf("no matching expected call: %T.%v(%v) [%s]\n%s", receiver, method, args, origin, err)
 	}
 
 	// Two things happen here:

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -129,7 +129,7 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	expected, err := ctrl.expectedCalls.FindMatch(receiver, method, args)
 	if err != nil {
 		origin := callerInfo(2)
-		ctrl.t.Fatalf("no matching expected call: %T.%v(%v) %s\n%s", receiver, method, args, origin, err)
+		ctrl.t.Fatalf("Unexpected call to %T.%v(%v) at %s because: %s", receiver, method, args, origin, err)
 	}
 
 	// Two things happen here:

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -58,6 +58,7 @@ package gomock
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"sync"
 )
 
@@ -114,7 +115,8 @@ func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method st
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
-	call := &Call{t: ctrl.t, receiver: receiver, method: method, methodType: methodType, args: margs, minCalls: 1, maxCalls: 1}
+	origin := callerInfo(2)
+	call := &Call{t: ctrl.t, receiver: receiver, method: method, methodType: methodType, args: margs, origin: origin, minCalls: 1, maxCalls: 1}
 
 	ctrl.expectedCalls.Add(call)
 	return call
@@ -126,7 +128,8 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 
 	expected := ctrl.expectedCalls.FindMatch(receiver, method, args)
 	if expected == nil {
-		ctrl.t.Fatalf("no matching expected call: %T.%v(%v)", receiver, method, args)
+		origin := callerInfo(2)
+		ctrl.t.Fatalf("no matching expected call: %T.%v(%v) [%s]", receiver, method, args, origin)
 	}
 
 	// Two things happen here:
@@ -180,4 +183,11 @@ func (ctrl *Controller) Finish() {
 	if failures {
 		ctrl.t.Fatalf("aborting test due to missing call(s)")
 	}
+}
+
+func callerInfo(skip int) string {
+	if _, file, line, ok := runtime.Caller(skip + 1); ok {
+		return fmt.Sprintf("%s:%d", file, line)
+	}
+	return "unknown file"
 }

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -129,7 +129,7 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	expected, err := ctrl.expectedCalls.FindMatch(receiver, method, args)
 	if err != nil {
 		origin := callerInfo(2)
-		ctrl.t.Fatalf("no matching expected call: %T.%v(%v) [%s]\n%s", receiver, method, args, origin, err)
+		ctrl.t.Fatalf("no matching expected call: %T.%v(%v) %s\n%s", receiver, method, args, origin, err)
 	}
 
 	// Two things happen here:


### PR DESCRIPTION
Hi. Thanks for gomock! I just started using it and thought it was not enough verbose when it comes to errors messages.

## The benefits
Before this PR, in my tests, I see an error: `no matching expected call`
```
GOROOT=/usr/local/go
GOPATH=/ide/work
/usr/local/go/bin/go test -c -i -o /tmp/TestHTTP_makeRequestUsingCustomClient_in_http_client_test_gogo 34-mock-http-client-with-gomock
/tmp/TestHTTP_makeRequestUsingCustomClient_in_http_client_test_gogo -test.v -test.run ^TestHTTP_makeRequestUsingCustomClient$
	controller.go:129: no matching expected call: *myhttp32.MockHTTPClientInterface.Do([0xc420074b00])
	controller.go:174: missing call(s) to *myhttp32.MockHTTPClientInterface.Do(is equal to &{GET some-urla HTTP/1.1 1 1 map[] <nil> <nil> 0 [] false  map[] map[] <nil> map[]   <nil> <nil> <nil> <nil>})
	controller.go:181: aborting test due to missing call(s)

Process finished with exit code 1
```
after this PR:
```
GOROOT=/usr/local/go
GOPATH=/ide/work
/usr/local/go/bin/go test -c -i -o /tmp/TestHTTP_makeRequestUsingCustomClient_in_http_client_test_gogo 34-mock-http-client-with-gomock
/tmp/TestHTTP_makeRequestUsingCustomClient_in_http_client_test_gogo -test.v -test.run ^TestHTTP_makeRequestUsingCustomClient$
	controller.go:132: no matching expected call: *myhttp32.MockHTTPClientInterface.Do([0xc42000af00]) /ide/work/src/34-mock-http-client-with-gomock/http_client.go:85
		
		The expected argument of index: 0 of this call: /ide/work/src/34-mock-http-client-with-gomock/http_client_test.go:68 did not match the actual argument.
		Actual argument: is equal to &{GET some-urla HTTP/1.1 1 1 map[] <nil> <nil> 0 [] false  map[] map[] <nil> map[]   <nil> <nil> <nil> <nil>}, expected: &{GET some-url HTTP/1.1 1 1 map[] <nil> <nil> 0 [] false  map[] map[] <nil> map[]   <nil> <nil> <nil> <nil>}
	controller.go:177: missing call(s) to *myhttp32.MockHTTPClientInterface.Do(is equal to &{GET some-urla HTTP/1.1 1 1 map[] <nil> <nil> 0 [] false  map[] map[] <nil> map[]   <nil> <nil> <nil> <nil>}) /ide/work/src/34-mock-http-client-with-gomock/http_client_test.go:68
	controller.go:184: aborting test due to missing call(s)

Process finished with exit code 1
```

## This PR contains
  1. The changes that https://github.com/golang/mock/pull/25 introduces. But it had conflicts in relation to [latest master](https://github.com/golang/mock/commit/13f360950a79f5864a972c786a10a50e44b69541) which I fixed.
  2. Changes to `FindMatch` method. It now also returns an error which explains why there was no call match. I added tests for each error explanation message kind.
  3. I removed the square brackets around call origin (path and line to method invocations), because this way, in [Gogland IDE](https://www.jetbrains.com/go/), they are displayed as clickable links.

## You may not like
   * the wording of error messages
   * the errors messages like :"Actual argument: is equal to 15, expected: 3".  It comes from [here](https://github.com/xmik/mock/blob/verbose-errors/gomock/controller_test.go#L302). It would be prettier if the error message was:  "Actual argument: 15, expected: 3". This is because in the [method returning this message](https://github.com/xmik/mock/blob/verbose-errors/gomock/call.go#L205), the `m` object is of type `Matcher`, and it has no public fields, so we can only use its `String()` method. I don't think it is greatly important.



Please voice any concerns and treat me as unexperienced in Go, as I've just recently started using it.