### PR TITLE
Support slices in SetArg()

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -118,7 +118,8 @@ func (c *Call) Times(n int) *Call {
 }
 
 // SetArg declares an action that will set the nth argument's value,
-// indirected through a pointer.
+// indirected through a pointer. Or, in the case of a slice, SetArg
+// will copy value's elements into the nth argument.
 func (c *Call) SetArg(n int, value interface{}) *Call {
 	if c.setArgs == nil {
 		c.setArgs = make(map[int]reflect.Value)

--- a/gomock/call_test.go
+++ b/gomock/call_test.go
@@ -1,6 +1,9 @@
 package gomock
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 type mockTestReporter struct {
 	errorCalls int
@@ -42,6 +45,35 @@ func TestCall_After(t *testing.T) {
 
 		if tr2.fatalCalls != 1 {
 			t.Errorf("number of fatal calls == %v, want 1", tr2.fatalCalls)
+		}
+	})
+}
+
+func TestCall_SetArg(t *testing.T) {
+	t.Run("SetArgSlice", func(t *testing.T) {
+		c := &Call{
+			methodType: reflect.TypeOf(func([]byte) {}),
+		}
+		c.SetArg(0, []byte{1, 2, 3})
+
+		in := []byte{4, 5, 6}
+		c.call([]interface{}{in})
+
+		if in[0] != 1 || in[1] != 2 || in[2] != 3 {
+			t.Error("Expected SetArg() to modify input slice argument")
+		}
+	})
+
+	t.Run("SetArgPointer", func(t *testing.T) {
+		c := &Call{
+			methodType: reflect.TypeOf(func(*int) {}),
+		}
+		c.SetArg(0, 42)
+
+		in := 43
+		c.call([]interface{}{&in})
+		if in != 42 {
+			t.Error("Expected SetArg() to modify value pointed to by argument")
 		}
 	})
 }


### PR DESCRIPTION
I needed this while trying to write tests against https://godoc.org/github.com/kidoman/embd#SPIBus

`SPIBus::TransferAndReceiveData([]byte)` writes its output back to the input byte slice.

Would also fix https://github.com/golang/mock/issues/27