### PR TITLE
retain ordering of expected calls

### DIFF
--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -43,11 +43,8 @@ func (cs callSet) Remove(call *Call) {
 	sl := methodMap[call.method]
 	for i, c := range sl {
 		if c == call {
-			// quick removal; we don't need to maintain call order
-			if len(sl) > 1 {
-				sl[i] = sl[len(sl)-1]
-			}
-			methodMap[call.method] = sl[:len(sl)-1]
+			// maintain order for remaining calls
+			methodMap[call.method] = append(sl[:i], sl[i+1:]...)
 			break
 		}
 	}


### PR DESCRIPTION
While writing tests for a stateful object, I noticed unexpected behavior
where the mock would use the 1st call, but then the 3rd expected call
before the 2nd (called in [1,3,2]).

Since our tests all used the `gomock.Any()` function param, there was no
ordering that could be detected by the matching without chaining all
calls with `After()`.