### PR TITLE
add tests for callSet Add & Remove

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -78,6 +78,7 @@ func (c *Call) Do(f interface{}) *Call {
 	return c
 }
 
+// Return declares the values to be returned by the mocked function call.
 func (c *Call) Return(rets ...interface{}) *Call {
 	mt := c.methodType
 	if len(rets) != mt.NumOut() {
@@ -112,6 +113,7 @@ func (c *Call) Return(rets ...interface{}) *Call {
 	return c
 }
 
+// Times declares the exact number of times a function call is expected to be executed.
 func (c *Call) Times(n int) *Call {
 	c.minCalls, c.maxCalls = n, n
 	return c
@@ -146,7 +148,7 @@ func (c *Call) SetArg(n int, value interface{}) *Call {
 	case reflect.Slice:
 		// nothing to do
 	default:
-		c.t.Fatalf("SetArg(%d, ...) referring to argument of non-pointer non-interface non-slice type %v",
+		c.t.Fatalf("SetArg(%d, ...) referring to argument of non-pointer non-interface non-slice type %v [%s]",
 			n, at, c.origin)
 	}
 	c.setArgs[n] = reflect.ValueOf(value)
@@ -204,7 +206,7 @@ func (c *Call) matches(args []interface{}) error {
 	}
 	for i, m := range c.args {
 		if !m.Matches(args[i]) {
-			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v\n",
+			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
 				c.origin, strconv.Itoa(i), args[i], m)
 		}
 	}

--- a/gomock/callset_test.go
+++ b/gomock/callset_test.go
@@ -1,0 +1,71 @@
+// Copyright 2011 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomock
+
+import "testing"
+
+func TestCallSetAdd(t *testing.T) {
+	methodVal := "TestMethod"
+	var receiverVal interface{} = "TestReceiver"
+	cs := make(callSet)
+
+	numCalls := 10
+	for i := 0; i < numCalls; i++ {
+		cs.Add(&Call{receiver: receiverVal, method: methodVal})
+	}
+
+	if len(cs) != 1 {
+		t.Errorf("expected only one reciever in callSet")
+	}
+	if numActualMethods := len(cs[receiverVal]); numActualMethods != 1 {
+		t.Errorf("expected only method on the reciever in callSet, found %d", numActualMethods)
+	}
+	if numActualCalls := len(cs[receiverVal][methodVal]); numActualCalls != numCalls {
+		t.Errorf("expected all %d calls in callSet, found %d", numCalls, numActualCalls)
+	}
+}
+
+func TestCallSetRemove(t *testing.T) {
+	methodVal := "TestMethod"
+	var receiverVal interface{} = "TestReceiver"
+
+	cs := make(callSet)
+	ourCalls := []*Call{}
+
+	numCalls := 10
+	for i := 0; i < numCalls; i++ {
+		// NOTE: abuse the `numCalls` value to convey initial ordering of mocked calls
+		generatedCall := &Call{receiver: receiverVal, method: methodVal, numCalls: i}
+		cs.Add(generatedCall)
+		ourCalls = append(ourCalls, generatedCall)
+	}
+
+	// validateOrder validates that the calls in the array are ordered as they were added
+	validateOrder := func(calls []*Call) {
+		// lastNum tracks the last `numCalls` (call order) value seen
+		lastNum := -1
+		for _, c := range calls {
+			if lastNum >= c.numCalls {
+				t.Errorf("found call %d after call %d", c.numCalls, lastNum)
+			}
+			lastNum = c.numCalls
+		}
+	}
+
+	for _, c := range ourCalls {
+		validateOrder(cs[receiverVal][methodVal])
+		cs.Remove(c)
+	}
+}


### PR DESCRIPTION
Adds tests to complement the changes introduced in #107.

I validated that these tests would have caught the ordering bug fixed by
PR #107 by reverting the change locally:

revert diff:
```diff
diff --git a/gomock/callset.go b/gomock/callset.go
index 05d6fa2..c652f42 100644
--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -44,7 +44,11 @@ func (cs callSet) Remove(call *Call) {
        for i, c := range sl {
                if c == call {
                        // maintain order for remaining calls
-                       methodMap[call.method] = append(sl[:i], sl[i+1:]...)
+                       // methodMap[call.method] = append(sl[:i], sl[i+1:]...)
+                       if len(sl) > 1 {
+                               sl[i] = sl[len(sl)-1]
+                       }
+                       methodMap[call.method] = sl[:len(sl)-1]
                        break
                }
        }
```

test output:
```
=== RUN   TestCallSetAdd
--- PASS: TestCallSetAdd (0.00s)
=== RUN   TestCallSetRemove
--- FAIL: TestCallSetRemove (0.00s)
	callset_test.go:61: found call 1 after call 9
	callset_test.go:61: found call 8 after call 9
	callset_test.go:61: found call 2 after call 8
	callset_test.go:61: found call 8 after call 9
	callset_test.go:61: found call 7 after call 8
	callset_test.go:61: found call 3 after call 7
	callset_test.go:61: found call 8 after call 9
	callset_test.go:61: found call 7 after call 8
	callset_test.go:61: found call 6 after call 7
	callset_test.go:61: found call 4 after call 6
	callset_test.go:61: found call 8 after call 9
	callset_test.go:61: found call 7 after call 8
	callset_test.go:61: found call 6 after call 7
	callset_test.go:61: found call 5 after call 6
	callset_test.go:61: found call 8 after call 9
	callset_test.go:61: found call 7 after call 8
	callset_test.go:61: found call 6 after call 7
	callset_test.go:61: found call 8 after call 9
	callset_test.go:61: found call 7 after call 8
	callset_test.go:61: found call 8 after call 9
```