### PR TITLE
mark gomock functions as test helpers

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -80,6 +80,10 @@ func (c *Call) Do(f interface{}) *Call {
 
 // Return declares the values to be returned by the mocked function call.
 func (c *Call) Return(rets ...interface{}) *Call {
+	if h, ok := c.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	mt := c.methodType
 	if len(rets) != mt.NumOut() {
 		c.t.Fatalf("wrong number of arguments to Return for %T.%v: got %d, want %d [%s]",
@@ -123,6 +127,10 @@ func (c *Call) Times(n int) *Call {
 // indirected through a pointer. Or, in the case of a slice, SetArg
 // will copy value's elements into the nth argument.
 func (c *Call) SetArg(n int, value interface{}) *Call {
+	if h, ok := c.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	if c.setArgs == nil {
 		c.setArgs = make(map[int]reflect.Value)
 	}
@@ -167,6 +175,10 @@ func (c *Call) isPreReq(other *Call) bool {
 
 // After declares that the call may only match after preReq has been exhausted.
 func (c *Call) After(preReq *Call) *Call {
+	if h, ok := c.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	if c == preReq {
 		c.t.Fatalf("A call isn't allowed to be its own prerequisite")
 	}

--- a/gomock/call_test.go
+++ b/gomock/call_test.go
@@ -18,6 +18,8 @@ func (o *mockTestReporter) Fatalf(format string, args ...interface{}) {
 	o.fatalCalls++
 }
 
+func (o *mockTestReporter) Helper() {}
+
 func TestCall_After(t *testing.T) {
 	t.Run("SelfPrereqCallsFatalf", func(t *testing.T) {
 		tr1 := &mockTestReporter{}
@@ -53,6 +55,7 @@ func TestCall_SetArg(t *testing.T) {
 	t.Run("SetArgSlice", func(t *testing.T) {
 		c := &Call{
 			methodType: reflect.TypeOf(func([]byte) {}),
+			t:          &mockTestReporter{},
 		}
 		c.SetArg(0, []byte{1, 2, 3})
 
@@ -67,6 +70,7 @@ func TestCall_SetArg(t *testing.T) {
 	t.Run("SetArgPointer", func(t *testing.T) {
 		c := &Call{
 			methodType: reflect.TypeOf(func(*int) {}),
+			t:          &mockTestReporter{},
 		}
 		c.SetArg(0, 42)
 

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -86,6 +86,10 @@ func NewController(t TestReporter) *Controller {
 }
 
 func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...interface{}) *Call {
+	if h, ok := ctrl.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	recv := reflect.ValueOf(receiver)
 	for i := 0; i < recv.Type().NumMethod(); i++ {
 		if recv.Type().Method(i).Name == method {
@@ -123,6 +127,10 @@ func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method st
 }
 
 func (ctrl *Controller) Call(receiver interface{}, method string, args ...interface{}) []interface{} {
+	if h, ok := ctrl.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
@@ -159,6 +167,10 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 }
 
 func (ctrl *Controller) Finish() {
+	if h, ok := ctrl.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
@@ -190,4 +202,9 @@ func callerInfo(skip int) string {
 		return fmt.Sprintf("%s:%d", file, line)
 	}
 	return "unknown file"
+}
+
+type testHelper interface {
+	TestReporter
+	Helper()
 }


### PR DESCRIPTION
Use Go 1.9's new "testing.T".Helper method to mark gomock's functions as
test helpers so that test failures print the caller's line and file
information instead of gomock's information.