### PR TITLE
Better error message

### DIFF
--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -16,35 +16,47 @@ package gomock
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 )
 
 // callSet represents a set of expected calls, indexed by receiver and method
 // name.
-type callSet map[interface{}]map[string][]*Call
+type callSet struct {
+	// Calls that are still expected.
+	expected map[callSetKey][]*Call
+	// Calls that have been exhausted.
+	exhausted map[callSetKey][]*Call
+}
+
+// callSetKey is the key in the maps in callSet
+type callSetKey struct {
+	receiver interface{}
+	fname    string
+}
+
+func newCallSet() *callSet {
+	return &callSet{make(map[callSetKey][]*Call), make(map[callSetKey][]*Call)}
+}
 
 // Add adds a new expected call.
 func (cs callSet) Add(call *Call) {
-	methodMap, ok := cs[call.receiver]
-	if !ok {
-		methodMap = make(map[string][]*Call)
-		cs[call.receiver] = methodMap
+	key := callSetKey{call.receiver, call.method}
+	m := cs.expected
+	if call.exhausted() {
+		m = cs.exhausted
 	}
-	methodMap[call.method] = append(methodMap[call.method], call)
+	m[key] = append(m[key], call)
 }
 
 // Remove removes an expected call.
 func (cs callSet) Remove(call *Call) {
-	methodMap, ok := cs[call.receiver]
-	if !ok {
-		return
-	}
-	sl := methodMap[call.method]
-	for i, c := range sl {
+	key := callSetKey{call.receiver, call.method}
+	calls := cs.expected[key]
+	for i, c := range calls {
 		if c == call {
 			// maintain order for remaining calls
-			methodMap[call.method] = append(sl[:i], sl[i+1:]...)
+			cs.expected[key] = append(calls[:i], calls[i+1:]...)
+			cs.exhausted[key] = append(cs.exhausted[key], call)
 			break
 		}
 	}
@@ -52,26 +64,12 @@ func (cs callSet) Remove(call *Call) {
 
 // FindMatch searches for a matching call. Returns error with explanation message if no call matched.
 func (cs callSet) FindMatch(receiver interface{}, method string, args []interface{}) (*Call, error) {
-	methodMap, ok := cs[receiver]
-	if !ok {
-		return nil, errors.New("there are no expected method calls for that receiver")
-	}
-	calls, ok := methodMap[method]
-	if !ok {
-		return nil, fmt.Errorf("there are no expected calls of the method: %s for that receiver", method)
-	}
+	key := callSetKey{receiver, method}
 
-	// Search through the unordered set of calls expected on a method on a
-	// receiver.
+	// Search through the expected calls.
+	expected := cs.expected[key]
 	var callsErrors bytes.Buffer
-	for _, call := range calls {
-		// A call should not normally still be here if exhausted,
-		// but it can happen if, for instance, .Times(0) was used.
-		// Pretend the call doesn't match.
-		if call.exhausted() {
-			callsErrors.WriteString("\nThe call was exhausted.")
-			continue
-		}
+	for _, call := range expected {
 		err := call.matches(args)
 		if err != nil {
 			fmt.Fprintf(&callsErrors, "\n%v", err)
@@ -80,5 +78,31 @@ func (cs callSet) FindMatch(receiver interface{}, method string, args []interfac
 		}
 	}
 
+	// If we haven't found a match then search through the exhausted calls so we
+	// get useful error messages.
+	exhausted := cs.exhausted[key]
+	for _, call := range exhausted {
+		if err := call.matches(args); err != nil {
+			fmt.Fprintf(&callsErrors, "\n%v", err)
+		}
+	}
+
+	if len(expected)+len(exhausted) == 0 {
+		fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q for that receiver", method)
+	}
+
 	return nil, fmt.Errorf(callsErrors.String())
+}
+
+// Failures returns the calls that are not satisfied.
+func (cs callSet) Failures() []*Call {
+	failures := make([]*Call, 0, len(cs.expected))
+	for _, calls := range cs.expected {
+		for _, call := range calls {
+			if !call.satisfied() {
+				failures = append(failures, call)
+			}
+		}
+	}
+	return failures
 }

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -169,7 +169,7 @@ func TestNoRecordedCallsForAReceiver(t *testing.T) {
 
 	reporter.assertFatal(func() {
 		ctrl.Call(subject, "NotRecordedMethod", "argument")
-	}, "Unexpected call to", "there are no expected method calls for that receiver")
+	}, "Unexpected call to", "there are no expected calls of the method \"NotRecordedMethod\" for that receiver")
 	ctrl.Finish()
 }
 
@@ -180,7 +180,7 @@ func TestNoRecordedMatchingMethodNameForAReceiver(t *testing.T) {
 	ctrl.RecordCall(subject, "FooMethod", "argument")
 	reporter.assertFatal(func() {
 		ctrl.Call(subject, "NotRecordedMethod", "argument")
-	}, "Unexpected call to", "there are no expected calls of the method: NotRecordedMethod for that receiver")
+	}, "Unexpected call to", "there are no expected calls of the method \"NotRecordedMethod\" for that receiver")
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.
 		ctrl.Finish()


### PR DESCRIPTION
Add a useful error message for when a call to the mock doesn't match any expected calls because they have been exhausted.

Some refactoring is included in order to make the tests easier to write.

Fixes #128