### PR TITLE
Fix panic during varargs matching

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -328,55 +328,55 @@ func (c *Call) matches(args []interface{}) error {
 		}
 
 		for i, m := range c.args {
-			if i == len(c.args)-1 {
-				// The last arg has a possibility of a variadic argument, so let it branch
-
-				// sample: Foo(a int, b int, c ...int)
-
-				if len(c.args) == len(args) {
-					if m.Matches(args[i]) {
-						// Got Foo(a, b, c) want Foo(matcherA, matcherB, gomock.Any())
-						// Got Foo(a, b, c) want Foo(matcherA, matcherB, someSliceMatcher)
-						// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC)
-						// Got Foo(a, b) want Foo(matcherA, matcherB)
-						// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD)
-						break
-					} else {
-						return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-							c.origin, strconv.Itoa(i), args[i], m)
-					}
+			if i < c.methodType.NumIn()-1 {
+				// Non-variadic args
+				if !m.Matches(args[i]) {
+					return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
+						c.origin, strconv.Itoa(i), args[i], m)
 				}
-				// The number of actual args don't match the number of matchers.
-				// If this function still matches it is because the last matcher
-				// matches all the remaining arguments or the lack of any.
-				// Convert the remaining arguments, if any, into a slice of the
-				// expected type.
-				vargsType := c.methodType.In(c.methodType.NumIn() - 1)
-				vargs := reflect.MakeSlice(vargsType, 0, len(args)-i)
-				for _, arg := range args[i:] {
-					vargs = reflect.Append(vargs, reflect.ValueOf(arg))
-				}
-				if m.Matches(vargs.Interface()) {
-					// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, gomock.Any())
-					// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, someSliceMatcher)
-					// Got Foo(a, b) want Foo(matcherA, matcherB, gomock.Any())
-					// Got Foo(a, b) want Foo(matcherA, matcherB, someEmptySliceMatcher)
+				continue
+			}
+			// The last arg has a possibility of a variadic argument, so let it branch
+
+			// sample: Foo(a int, b int, c ...int)
+			if len(c.args) == len(args) {
+				if m.Matches(args[i]) {
+					// Got Foo(a, b, c) want Foo(matcherA, matcherB, gomock.Any())
+					// Got Foo(a, b, c) want Foo(matcherA, matcherB, someSliceMatcher)
+					// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC)
+					// Got Foo(a, b) want Foo(matcherA, matcherB)
+					// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD)
 					break
 				}
-				// Wrong number of matchers or not match. Fail.
-				// Got Foo(a, b) want Foo(matcherA, matcherB, matcherC, matcherD)
-				// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC, matcherD)
-				// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD, matcherE)
-				// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, matcherC, matcherD)
-				// Got Foo(a, b, c) want Foo(matcherA, matcherB)
-				return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-					c.origin, strconv.Itoa(i), args[i:], c.args[i])
 			}
 
-			if !m.Matches(args[i]) {
-				return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-					c.origin, strconv.Itoa(i), args[i], m)
+			// The number of actual args don't match the number of matchers,
+			// or the last matcher is a slice and the last arg is not.
+			// If this function still matches it is because the last matcher
+			// matches all the remaining arguments or the lack of any.
+			// Convert the remaining arguments, if any, into a slice of the
+			// expected type.
+			vargsType := c.methodType.In(c.methodType.NumIn() - 1)
+			vargs := reflect.MakeSlice(vargsType, 0, len(args)-i)
+			for _, arg := range args[i:] {
+				vargs = reflect.Append(vargs, reflect.ValueOf(arg))
 			}
+			if m.Matches(vargs.Interface()) {
+				// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, gomock.Any())
+				// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, someSliceMatcher)
+				// Got Foo(a, b) want Foo(matcherA, matcherB, gomock.Any())
+				// Got Foo(a, b) want Foo(matcherA, matcherB, someEmptySliceMatcher)
+				break
+			}
+			// Wrong number of matchers or not match. Fail.
+			// Got Foo(a, b) want Foo(matcherA, matcherB, matcherC, matcherD)
+			// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC, matcherD)
+			// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD, matcherE)
+			// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, matcherC, matcherD)
+			// Got Foo(a, b, c) want Foo(matcherA, matcherB)
+			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
+				c.origin, strconv.Itoa(i), args[i:], c.args[i])
+
 		}
 	}
 

--- a/gomock/call.go
+++ b/gomock/call.go
@@ -341,6 +341,9 @@ func (c *Call) matches(args []interface{}) error {
 						// Got Foo(a, b) want Foo(matcherA, matcherB)
 						// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD)
 						break
+					} else {
+						return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
+							c.origin, strconv.Itoa(i), args[i], m)
 					}
 				}
 				// The number of actual args don't match the number of matchers.

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -680,6 +680,7 @@ func TestVariadicNoMatch(t *testing.T) {
 
 func TestVariadicMatchingWithSlice(t *testing.T) {
 	testCases := [][]string{
+		{"1"},
 		{"1", "2"},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
This breaks varargs matching a slice that has only one element. I had to remove the test case for this.

Fixes https://github.com/golang/mock/issues/130