### PR TITLE
Fatal on duplicate Controller.Finish call

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -77,6 +77,7 @@ type Controller struct {
 	mu            sync.Mutex
 	t             TestReporter
 	expectedCalls *callSet
+	finished      bool
 }
 
 func NewController(t TestReporter) *Controller {
@@ -181,6 +182,11 @@ func (ctrl *Controller) Finish() {
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
+
+	if ctrl.finished {
+		ctrl.t.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
+	}
+	ctrl.finished = true
 
 	// If we're currently panicking, probably because this is a deferred call,
 	// pass through the panic.

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -701,3 +701,12 @@ func TestVariadicMatchingWithSlice(t *testing.T) {
 		})
 	}
 }
+
+func TestDuplicateFinishCallFails(t *testing.T) {
+	rep, ctrl := createFixtures(t)
+
+	ctrl.Finish()
+	rep.assertPass("the first Finish call should succeed")
+
+	rep.assertFatal(ctrl.Finish, "Controller.Finish was called more than once. It has to be called exactly once.")
+}


### PR DESCRIPTION
Failing with `t.Fatal` in case of multiple `Finish` calls on the same controller instance.

This would prevent sharing the same controller between subtests.