### PR TITLE
Rename aux -> faux

### DIFF
--- a/mockgen/tests/aux_imports_embedded_interface/bugreport.go
+++ b/mockgen/tests/aux_imports_embedded_interface/bugreport.go
@@ -1,16 +1,16 @@
-//go:generate mockgen -aux_files aux=aux/aux.go -destination bugreport_mock.go -package bugreport -source=bugreport.go Example
+//go:generate mockgen -aux_files faux=faux/faux.go -destination bugreport_mock.go -package bugreport -source=bugreport.go Example
 
 package bugreport
 
 import (
 	"log"
 
-	"github.com/golang/mock/mockgen/tests/aux_imports_embedded_interface/aux"
+	"github.com/golang/mock/mockgen/tests/aux_imports_embedded_interface/faux"
 )
 
 // Source is an interface w/ an embedded foreign interface
 type Source interface {
-	aux.Foreign
+	faux.Foreign
 }
 
 func CallForeignMethod(s Source) {

--- a/mockgen/tests/aux_imports_embedded_interface/bugreport_mock.go
+++ b/mockgen/tests/aux_imports_embedded_interface/bugreport_mock.go
@@ -6,7 +6,7 @@ package bugreport
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	aux "github.com/golang/mock/mockgen/tests/aux_imports_embedded_interface/aux"
+	faux "github.com/golang/mock/mockgen/tests/aux_imports_embedded_interface/faux"
 	reflect "reflect"
 )
 
@@ -34,9 +34,9 @@ func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 }
 
 // Method mocks base method
-func (m *MockSource) Method() aux.Return {
+func (m *MockSource) Method() faux.Return {
 	ret := m.ctrl.Call(m, "Method")
-	ret0, _ := ret[0].(aux.Return)
+	ret0, _ := ret[0].(faux.Return)
 	return ret0
 }
 

--- a/mockgen/tests/aux_imports_embedded_interface/faux/faux.go
+++ b/mockgen/tests/aux_imports_embedded_interface/faux/faux.go
@@ -1,4 +1,4 @@
-package aux
+package faux
 
 type Foreign interface {
 	Method() Return


### PR DESCRIPTION
- `aux` is not a valid directory name on windows
- Fixes https://github.com/golang/mock/pull/134#issuecomment-349758272
