### PR TITLE
New matcher: gomock.AssignableToTypeOf

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -87,6 +87,18 @@ func (n notMatcher) String() string {
 	return "not(" + n.m.String() + ")"
 }
 
+type assignableToTypeOfMatcher struct {
+	targetType reflect.Type
+}
+
+func (m assignableToTypeOfMatcher) Matches(x interface{}) bool {
+	return reflect.TypeOf(x).AssignableTo(m.targetType)
+}
+
+func (m assignableToTypeOfMatcher) String() string {
+	return "is assignable to " + m.targetType.Name()
+}
+
 // Constructors
 func Any() Matcher             { return anyMatcher{} }
 func Eq(x interface{}) Matcher { return eqMatcher{x} }
@@ -96,4 +108,17 @@ func Not(x interface{}) Matcher {
 		return notMatcher{m}
 	}
 	return notMatcher{Eq(x)}
+}
+
+// AssignableToTypeOf is a Matcher that matches if the parameter to the mock
+// function is assignable to the type of the parameter to this function.
+//
+// Example usage:
+//
+// 		dbMock.EXPECT().
+// 			Insert(gomock.AssignableToTypeOf(&EmployeeRecord{})).
+// 			Return(errors.New("DB error"))
+//
+func AssignableToTypeOf(x interface{}) Matcher {
+	return assignableToTypeOfMatcher{reflect.TypeOf(x)}
 }

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -68,3 +68,50 @@ func TestNotMatcher(t *testing.T) {
 		t.Errorf("notMatcher should match 5")
 	}
 }
+
+type Dog struct {
+	Breed, Name string
+}
+
+// A thorough test of assignableToTypeOfMatcher
+func TestAssignableToTypeOfMatcher(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	aStr := "def"
+	anotherStr := "ghi"
+
+	if match := gomock.AssignableToTypeOf("abc").Matches(4); match {
+		t.Errorf(`AssignableToTypeOf("abc") should not match 4`)
+	}
+	if match := gomock.AssignableToTypeOf("abc").Matches(&aStr); match {
+		t.Errorf(`AssignableToTypeOf("abc") should not match &aStr (*string)`)
+	}
+	if match := gomock.AssignableToTypeOf("abc").Matches("def"); !match {
+		t.Errorf(`AssignableToTypeOf("abc") should match "def"`)
+	}
+	if match := gomock.AssignableToTypeOf(&aStr).Matches("abc"); match {
+		t.Errorf(`AssignableToTypeOf(&aStr) should not match "abc"`)
+	}
+	if match := gomock.AssignableToTypeOf(&aStr).Matches(&anotherStr); !match {
+		t.Errorf(`AssignableToTypeOf(&aStr) should match &anotherStr`)
+	}
+	if match := gomock.AssignableToTypeOf(0).Matches(4); !match {
+		t.Errorf(`AssignableToTypeOf(0) should match 4`)
+	}
+	if match := gomock.AssignableToTypeOf(0).Matches("def"); match {
+		t.Errorf(`AssignableToTypeOf(0) should not match "def"`)
+	}
+	if match := gomock.AssignableToTypeOf(Dog{}).Matches(&Dog{}); match {
+		t.Errorf(`AssignableToTypeOf(Dog{}) should not match &Dog{}`)
+	}
+	if match := gomock.AssignableToTypeOf(Dog{}).Matches(Dog{Breed: "pug", Name: "Fido"}); !match {
+		t.Errorf(`AssignableToTypeOf(Dog{}) should match Dog{Breed: "pug", Name: "Fido"}`)
+	}
+	if match := gomock.AssignableToTypeOf(&Dog{}).Matches(Dog{}); match {
+		t.Errorf(`AssignableToTypeOf(&Dog{}) should not match Dog{}`)
+	}
+	if match := gomock.AssignableToTypeOf(&Dog{}).Matches(&Dog{Breed: "pug", Name: "Fido"}); !match {
+		t.Errorf(`AssignableToTypeOf(&Dog{}) should match &Dog{Breed: "pug", Name: "Fido"}`)
+	}
+}


### PR DESCRIPTION
This is the exact same idea as https://github.com/golang/mock/pull/132 from @josh-tepper, because I forgot to check for an existing PR for this feature before writing the code (!). But then I took some of the ideas from that PR and merged them with my code to create this PR, which has unit tests and documentation. So this should be a considered a team effort from @josh-tepper and me.

This is very useful when mocking functions that take `interface{}` parameters.

For example, let's say I need to have a mock for this interface:

```go
type Inserter interface {
    Insert(list ...interface{}) error
}
```

Using this matcher lets me take:

```go
	dbMock.EXPECT().
		Insert(gomock.Any()).
		Return(errors.New("DB error"))
```

and change it go:

```go
	dbMock.EXPECT().
		Insert(gomock.AssignableToTypeOf(&EmployeeRecord{})).
		Return(errors.New("DB error"))
```

which makes the test much more readable because I can see at a glance what is being inserted, which could be important if the code under test does multiple inserts to different tables. Also if I am expecting the mock to be called with a certain type of parameter and it gets called with a different type, the test failure will let me know right away that my assumption was wrong.

Cc: @balshetzer, @seanisom, @iderdik, @shylu, @abarla2010
  