### PR TITLE
Fix bug with comparing variadic arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 # The mockgen binary.
 mockgen/mockgen
 
-# A binary produced by gotest.
+# Binaries produced by gotest.
 #gomock/[568]\.out
+*.test

--- a/gomock/call.go
+++ b/gomock/call.go
@@ -340,13 +340,14 @@ func (c *Call) matches(args []interface{}) error {
 
 			// sample: Foo(a int, b int, c ...int)
 			if len(c.args) == len(args) {
+				// we have the same number of args, so iterate through them all to make sure they match
 				if m.Matches(args[i]) {
 					// Got Foo(a, b, c) want Foo(matcherA, matcherB, gomock.Any())
 					// Got Foo(a, b, c) want Foo(matcherA, matcherB, someSliceMatcher)
 					// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC)
 					// Got Foo(a, b) want Foo(matcherA, matcherB)
 					// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD)
-					break
+					continue
 				}
 			}
 

--- a/sample/user_test.go
+++ b/sample/user_test.go
@@ -74,7 +74,16 @@ func TestVariadicFunction(t *testing.T) {
 			sum += value
 		}
 		if sum != 7 {
-			t.Errorf("Expected 7, got %d", sum)
+			t.Errorf("[exact] Expected 7, got %d", sum)
+		}
+	})
+	mockIndex.EXPECT().Ellip("%d", 0, 1, 1, 2, 4).Do(func(format string, nums ...int) {
+		sum := 0
+		for _, value := range nums {
+			sum += value
+		}
+		if sum != 8 {
+			t.Errorf("[exact] Expected 8, got %d", sum)
 		}
 	})
 	mockIndex.EXPECT().Ellip("%d", gomock.Any()).Do(func(format string, nums ...int) {
@@ -83,7 +92,7 @@ func TestVariadicFunction(t *testing.T) {
 			sum += value
 		}
 		if sum != 7 {
-			t.Errorf("Expected 7, got %d", sum)
+			t.Errorf("[any] Expected 7, got %d", sum)
 		}
 	})
 	mockIndex.EXPECT().Ellip("%d", gomock.Any()).Do(func(format string, nums ...int) {
@@ -92,7 +101,7 @@ func TestVariadicFunction(t *testing.T) {
 			sum += value
 		}
 		if sum != 0 {
-			t.Errorf("Expected 0, got %d", sum)
+			t.Errorf("[any] Expected 0, got %d", sum)
 		}
 	})
 	mockIndex.EXPECT().Ellip("%d", gomock.Any()).Do(func(format string, nums ...int) {
@@ -101,7 +110,7 @@ func TestVariadicFunction(t *testing.T) {
 			sum += value
 		}
 		if sum != 0 {
-			t.Errorf("Expected 0, got %d", sum)
+			t.Errorf("[any] Expected 0, got %d", sum)
 		}
 	})
 	mockIndex.EXPECT().Ellip("%d").Do(func(format string, nums ...int) {
@@ -110,10 +119,12 @@ func TestVariadicFunction(t *testing.T) {
 			sum += value
 		}
 		if sum != 0 {
-			t.Errorf("Expected 0, got %d", sum)
+			t.Errorf("[none] Expected 0, got %d", sum)
 		}
 	})
 
+	// NOTE: switch order on first two in order to ensure all variadic arguments are matched when they equal the expectation
+	mockIndex.Ellip("%d", 0, 1, 1, 2, 4)
 	mockIndex.Ellip("%d", 0, 1, 1, 2, 3)
 	mockIndex.Ellip("%d", 0, 1, 1, 2, 3)
 	mockIndex.Ellip("%d", 0)


### PR DESCRIPTION
Introduced in either 7dc66f5f789eca1f66e82966331cde181184e62e or f159d62078cd1ee294e58036af3e8809ec88de8b, I can't tell which one.

The current code with variadic arguments on a mock will compare the first of those arguments, but then it breaks and doesn't compare the rest. This leads to both false equivalency, and the side effect of returning the wrong values from a partially matched mock.