### PR TITLE
support argument capture matcher

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -87,6 +87,29 @@ func (n notMatcher) String() string {
 	return "not(" + n.m.String() + ")"
 }
 
+type ArgumentCaptor struct {
+	values []interface{}
+}
+
+func (a *ArgumentCaptor) GetSingle() interface{} {
+	return a.values[0]
+}
+
+func (a *ArgumentCaptor) GetAll() []interface{} {
+	return a.values
+}
+
+func (a *ArgumentCaptor) Matches(x interface{}) bool {
+	a.values = append(a.values, x)
+	// as we just capture the value
+	return true
+}
+
+func (a *ArgumentCaptor) String() string {
+	// it never happens so just return some dummy value
+	return "ArgumentCaptor"
+}
+
 // Constructors
 func Any() Matcher             { return anyMatcher{} }
 func Eq(x interface{}) Matcher { return eqMatcher{x} }
@@ -97,3 +120,4 @@ func Not(x interface{}) Matcher {
 	}
 	return notMatcher{Eq(x)}
 }
+func CaptureArgument() Matcher { return &ArgumentCaptor{make([]interface{}, 0)} }

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -68,3 +68,32 @@ func TestNotMatcher(t *testing.T) {
 		t.Errorf("notMatcher should match 5")
 	}
 }
+
+func TestCaptureArgument(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockMatcher := mock_matcher.NewMockMatcher(ctrl)
+	notMatcher := gomock.Not(mockMatcher)
+
+	argumentCaptor := gomock.CaptureArgument().(*gomock.ArgumentCaptor)
+	mockMatcher.EXPECT().Matches(argumentCaptor).Return(true).Times(2)
+
+	arbitraryInput1 := 5
+	arbitraryInput2 := 6
+	notMatcher.Matches(arbitraryInput1)
+	notMatcher.Matches(arbitraryInput2)
+
+	capturedArguments := argumentCaptor.GetAll()
+	if len(capturedArguments) != 2 {
+		t.Errorf("ArgumentCaptor should capture 2 values")
+	}
+	actualArgument1 := argumentCaptor.GetSingle()
+	if actualArgument1 != arbitraryInput1 {
+		t.Errorf("input value [%d] was not captured", arbitraryInput1)
+	}
+	actualArgument2 := capturedArguments[1]
+	if actualArgument2 != arbitraryInput2 {
+		t.Errorf("input value [%d] was not captured", arbitraryInput2)
+	}
+}


### PR DESCRIPTION
Allows capturing arguments that are passed to the mocked function call

```
argumentCaptor := gomock.CaptureArgument().(*gomock.ArgumentCaptor)
someMock.EXPECT().SomeMethod(argumentCaptor).Return(abc).Time(2)

foo.Bar() // internally call someMock.SomeMethod(...)

capturedArguments := argumentCaptor.GetAll() // slice contains 2 as .Time(2) above
// or
singleArgument := argumentCaptor.GetSingle() // first value
```