### PR TITLE
Implement Matchers for "loose" variadic argument matching: All, Len, Contains

### DIFF
--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -35,6 +35,29 @@ func TestMatchers(t *testing.T) {
 			[]e{nil, (error)(nil), (chan bool)(nil), (*int)(nil)},
 			[]e{"", 0, make(chan bool), errors.New("err"), new(int)}},
 		testCase{gomock.Not(gomock.Eq(4)), []e{3, "blah", nil, int64(4)}, []e{4}},
+		testCase{gomock.Len(2),
+			[]e{[]int{1, 2}, []string{"foo", "bar"}},
+			[]e{[]interface{}{nil, nil, nil}},
+		},
+		testCase{gomock.Contains([]int{1, 2, 3}, []int{4, 5, 6}),
+			[]e{[][]int{{4, 5, 6}, {1, 2, 3}}},
+			[]e{[][]int{{1, 2, 4}, {3, 5, 6}, {1, 2, 3}}},
+		},
+		testCase{gomock.Contains("foo", "bar", "baz"),
+			[]e{
+				[]string{"foo", "bar", "baz"},
+				[]string{"foo", "bar", "baz", "qux"},
+			},
+			[]e{
+				1,
+				[]int{1, 2, 3},
+				[]string{"foo", "bar"},
+			},
+		},
+		testCase{gomock.All(gomock.Len(3), gomock.Contains(1, 2)),
+			[]e{[]int{1, 2, 3}, []int{10, 2, 1}},
+			[]e{[]int{4, 5, 6}, []int{1, 2, 3, 4}},
+		},
 	}
 	for i, test := range tests {
 		for _, x := range test.yes {


### PR DESCRIPTION
This PR provides a middle-ground approach to recording variadic argument conditions, between simply using `gomock.Any()` (accepting any list of argument values) or matching against exact argument lists. To that effect, we provide two Matchers to allow for "looser" matching of variadic parameters, including:
* `Contains`, which allows you to associate expected mock behavior with variadic argument lists simply containing one or more values; and
* `Len`, which likewise allows you to associate with lists of certain length.

This PR also provides an `All` compound Matcher, which, for example, can be used—in conjunction with both `Contains` and `Len`—to match against unordered values of a variadic argument slice.