### PR TITLE
Return last call for InOrder

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -402,10 +402,16 @@ func (c *Call) call(args []interface{}) []func([]interface{}) []interface{} {
 }
 
 // InOrder declares that the given calls should occur in order.
-func InOrder(calls ...*Call) {
+func InOrder(calls ...*Call) (last *Call) {
+	if len(calls) == 1 {
+		return calls[0]
+	}
+
 	for i := 1; i < len(calls); i++ {
 		calls[i].After(calls[i-1])
+		last = calls[i]
 	}
+	return
 }
 
 func setSlice(arg interface{}, v reflect.Value) {


### PR DESCRIPTION
The following changes InOrder to return the last called Call. This
allows a more fluent design when using InOrder, things can be better
chained together and allows composing of numerous InOrder calls.

Example:
```go
func doX(ctrl *gomock.Controller) *gomock.Call {
    mock := NewMockA(ctrl)
    return gomock.InOrder(
        doZ(mock),
        mock.EXPECT().Foo().Return("bar"),
    )
}

func doY(ctrl *gomock.Controller) *gomock.Call {
    mock := NewMockB(ctrl)
    return gomock.InOrder(
        doZ(mock),
        mock.EXPECT().Bar().Return("foo"),
    )
}

gomock.InOrder(
    doX(ctrl),
    doY(ctrl),
)
```