### PR TITLE
fix outdated reference to update_mock.sh script

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -8,8 +8,8 @@ interface that can be mocked with GoMock. The interesting files are:
     interfaces from `user.go` are used. This demonstrates how to create mock
     objects, set up expectations, and so on.
 
- *  `mock_user/mock_user.go`: The generated mock code. See ../update_mocks.sh
-    for the command used to generate it.
+ *  `mock_user/mock_user.go`: The generated mock code. See ../gomock/matchers.go
+    for the `go:generate` command used to generate it.
 
 To run the test,
 


### PR DESCRIPTION
update_mock.sh script was deleted in 2f85419.

Fixes #142.