### PR TITLE
fixed #156 context import collision

### DIFF
--- a/mockgen/parse_test.go
+++ b/mockgen/parse_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -68,6 +69,22 @@ func TestImportsOfFile(t *testing.T) {
 
 	imports := importsOfFile(file)
 	checkGreeterImports(t, imports)
+}
+
+func TestImportsOfFileContext(t *testing.T) {
+	// this test will fail if double import is detected with golang.org/x/net/context
+	// and context in the same package
+	ParseFile("tests/golang_x_context/pass.go")
+	failed := false
+	msg := ""
+	fatalf = func(format string, v ...interface{}) {
+		failed = true
+		msg = fmt.Sprintf(format, v)
+	}
+	ParseFile("tests/golang_x_context/fail.go")
+	if !failed {
+		t.Fatalf(msg)
+	}
 }
 
 func checkGreeterImports(t *testing.T, imports map[string]string) {

--- a/mockgen/tests/golang_x_context/fail.go
+++ b/mockgen/tests/golang_x_context/fail.go
@@ -1,0 +1,8 @@
+package sample
+
+import "github.com/golang/mock/mockgen/tests/golang_x_context/fail"
+
+// FailInterface creates a collision
+type FailInterface interface {
+	fail.Context
+}

--- a/mockgen/tests/golang_x_context/fail/context.go
+++ b/mockgen/tests/golang_x_context/fail/context.go
@@ -1,0 +1,9 @@
+package fail
+
+import "golang.org/x/net/context"
+
+// Context generates a package collision when this file is parsed
+// from another file
+type Context interface {
+	Get() context.Context
+}

--- a/mockgen/tests/golang_x_context/fail/dup.go
+++ b/mockgen/tests/golang_x_context/fail/dup.go
@@ -1,0 +1,7 @@
+package fail
+
+import context "fmt"
+
+func fail(msg string) string {
+	return context.Sprintf("demo %s", msg)
+}

--- a/mockgen/tests/golang_x_context/pass.go
+++ b/mockgen/tests/golang_x_context/pass.go
@@ -1,0 +1,8 @@
+package sample
+
+import "github.com/golang/mock/mockgen/tests/golang_x_context/pass"
+
+// PassInterface parses correctly
+type PassInterface interface {
+	pass.Context
+}

--- a/mockgen/tests/golang_x_context/pass/context.go
+++ b/mockgen/tests/golang_x_context/pass/context.go
@@ -1,0 +1,9 @@
+package pass
+
+import "golang.org/x/net/context"
+
+// Context parses correctly when using go context and golang.org/x/net/context
+// included in this package and called from another file in another package
+type Context interface {
+	Get() context.Context
+}

--- a/mockgen/tests/golang_x_context/pass/dup.go
+++ b/mockgen/tests/golang_x_context/pass/dup.go
@@ -1,0 +1,7 @@
+package pass
+
+import "context"
+
+func pass() context.Context {
+	return context.Background()
+}


### PR DESCRIPTION
This addresses the issue where a package imports another package with context
and golang.org/x/net/context in the same included package. This is leagal since
golang.org/x/net/context is an alias for context. We still don't want other
aliases to context to pass. There are tests that varify that only context and
golang.org/x/net/context are compatable for this special case.