### PR TITLE
Fatal can only be called once

### DIFF
--- a/gomock/call_test.go
+++ b/gomock/call_test.go
@@ -17,6 +17,10 @@ func (o *mockTestReporter) Fatalf(format string, args ...interface{}) {
 	o.fatalCalls++
 }
 
+func (o *mockTestReporter) Failed() bool {
+	return o.fatalCalls > 0
+}
+
 func (o *mockTestReporter) Helper() {}
 
 func TestCall_After(t *testing.T) {


### PR DESCRIPTION
It is invalid to call Fatal more than once. Finish currently will call Fatal again in some cases.