### PR TITLE
remove full path from callerInfo

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -46,7 +46,14 @@ type Call struct {
 
 // newCall creates a *Call. It requires the method type in order to support
 // unexported methods.
-func newCall(t TestHelper, receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
+func newCall(
+	t TestHelper,
+	receiver interface{},
+	method string,
+	methodType reflect.Type,
+	callerInfo func(int) string,
+	args ...interface{},
+) *Call {
 	t.Helper()
 
 	// TODO: check arity, types.

--- a/gomock/callset_test.go
+++ b/gomock/callset_test.go
@@ -27,10 +27,11 @@ func TestCallSetAdd(t *testing.T) {
 	method := "TestMethod"
 	var receiver interface{} = "TestReceiver"
 	cs := newCallSet()
+	nopCallerInfo := func(int) string { return "" }
 
 	numCalls := 10
 	for i := 0; i < numCalls; i++ {
-		cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
+		cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func), nopCallerInfo))
 	}
 
 	call, err := cs.FindMatch(receiver, method, []interface{}{})


### PR DESCRIPTION
The test package provides enough context on where the file is located.