### PR TITLE
Resolves #147 - Including binaries with tagged releases via GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+# Release automation via GoReleaser (goreleaser.com)
+# Requires a valid GITHUB_TOKEN envar prior to running `goreleaser`
+# See https://goreleaser.com/environment/ for more info
+---
+release:
+  github:
+    owner: golang
+    name: mock
+
+builds:
+  - binary: mockgen
+    goos:
+      - darwin
+      - windows
+      - linux
+    goarch:
+      - amd64
+      - 386
+    env:
+      - CGO_ENABLED=0
+    main: ./mockgen/
+archive:
+  format: tar.gz
+  wrap_in_directory: true
+  name_template: '{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  files:
+    - LICENSE
+    - README.md
+checksum:
+  name_template: '{{ .Binary }}-{{ .Version }}-checksums.txt'
+snapshot:
+  name_template: "snap-{{ .Commit }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - 'README'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,9 @@ builds:
       - 386
     env:
       - CGO_ENABLED=0
+      - GO111MODULE=on
+      - GOPROXY=https://proxy.golang.org
+      - GOSUMDB=sum.golang.org
     main: ./mockgen/
 archive:
   format: tar.gz


### PR DESCRIPTION
[GoReleaser](https://goreleaser.com) provides an easy way to automate releases via a single config YAML. You can see what the result would look like on my [fork's releases](https://github.com/scevallos/mock/releases). The maintainers of this repo would have to generate a valid GitHub Token and set it as an envvar as specified [here](https://goreleaser.com/environment/). This step can also be [integrated with Travis](https://goreleaser.com/ci/), if the maintainers want to do that.