### PR TITLE
mockgen: log error while deleting temp directory

### DIFF
--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"go/build"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,7 +97,11 @@ func runInDir(program []byte, dir string) (*model.Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { os.RemoveAll(tmpDir) }()
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Printf("failed to remove temp directory: %s", err)
+		}
+	}()
 	const progSource = "prog.go"
 	var progBinary = "prog.bin"
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Previously the temp directory was deleted via a defer, however the error
message was ignored.