### PR TITLE
Fix import path for packages inside $GOPATH/src/vendor

### DIFF
--- a/mockgen/model/model_test.go
+++ b/mockgen/model/model_test.go
@@ -17,9 +17,14 @@ func TestImpPath(t *testing.T) {
 	}{
 		{"foo/bar", "foo/bar"},
 		{"vendor/foo/bar", "foo/bar"},
+		{"vendor/foo/vendor/bar", "bar"},
 		{"/vendor/foo/bar", "foo/bar"},
 		{"qux/vendor/foo/bar", "foo/bar"},
 		{"qux/vendor/foo/vendor/bar", "bar"},
+		{"govendor/foo", "govendor/foo"},
+		{"foo/govendor/bar", "foo/govendor/bar"},
+		{"vendors/foo", "vendors/foo"},
+		{"foo/vendors/bar", "foo/vendors/bar"},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("input %s", tc.input), func(t *testing.T) {
@@ -28,5 +33,4 @@ func TestImpPath(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/mockgen/model/model_test.go
+++ b/mockgen/model/model_test.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestImpPath(t *testing.T) {
+	nonVendor := "github.com/foo/bar"
+	if nonVendor != impPath(nonVendor) {
+		t.Errorf("")
+
+	}
+	testCases := []struct {
+		input string
+		want  string
+	}{
+		{"foo/bar", "foo/bar"},
+		{"vendor/foo/bar", "foo/bar"},
+		{"/vendor/foo/bar", "foo/bar"},
+		{"qux/vendor/foo/bar", "foo/bar"},
+		{"qux/vendor/foo/vendor/bar", "bar"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("input %s", tc.input), func(t *testing.T) {
+			if got := impPath(tc.input); got != tc.want {
+				t.Errorf("got %s; want %s", got, tc.want)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
This PR changes the search string of a vendor package's import path from `/vendor/` to  `vendor/` so that packages inside `$GOPATH/src/vendor` are properly imported in the generated mocks.

The reasoning is that `t.PkgPath()` for package `$GOPATH/src/vendor/foo` is `vendor/foo` while current code only checks against `/vendor/`, which does not cover the packages inside `$GOPATH/src/vendor`.

This PR fixes https://github.com/golang/mock/issues/276.