### PR TITLE
remove go 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.10.x
   - 1.11.x
   - 1.12.x
 


### PR DESCRIPTION
Go only supports 1.11 and 1.12 at this point. Is it necessary to maintain 1.10?