### PR TITLE
ci: adds check to ensure go modules are up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ script:
   - go install github.com/golang/mock/mockgen
   - ./ci/check_go_fmt.sh
   - ./ci/check_go_generate.sh
+  - ./ci/check_go_mod.sh
   - go test -v ./...

--- a/ci/check_go_mod.sh
+++ b/ci/check_go_mod.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This script is used to ensure that the go.mod file is up to date.
+
+set -euo pipefail
+
+go mod tidy
+
+if [ ! -z "$(git status --porcelain)" ]; then
+    git status
+    echo
+    echo "The go.mod is not up to date."
+    exit 1
+fi


### PR DESCRIPTION
This should help prevent #289 for future commits.