### PR TITLE
fix callserrors with empty msg

### DIFF
--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -87,8 +87,13 @@ func (cs callSet) FindMatch(receiver interface{}, method string, args []interfac
 		}
 	}
 
-	if len(expected)+len(exhausted) == 0 {
+	expectedNum := len(expected)
+	exhaustedNum := len(exhausted)
+
+	if expectedNum+exhaustedNum == 0 {
 		fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q for that receiver", method)
+	} else if exhaustedNum > 0 && callsErrors.Len() == 0 {
+		fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q in that order", method)
 	}
 
 	return nil, fmt.Errorf(callsErrors.String())

--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -90,7 +90,7 @@ func (cs callSet) FindMatch(receiver interface{}, method string, args []interfac
 	expectedNum := len(expected)
 	exhaustedNum := len(exhausted)
 
-	if expectedNum+exhaustedNum == 0 {
+	if expectedNum == 0 && exhaustedNum == 0 {
 		fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q for that receiver", method)
 	} else if exhaustedNum > 0 && callsErrors.Len() == 0 {
 		fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q in that order", method)


### PR DESCRIPTION
Fix #291 

check exhaustedNum and callsErrors.len() , if it's true, fill with error msg