### PR TITLE
Allow mockgen to execute from outside Go modules

### DIFF
--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -47,7 +47,7 @@ func parseFile(source string) (*model.Package, error) {
 		return nil, fmt.Errorf("failed getting source directory: %v", err)
 	}
 
-	cfg := &packages.Config{Mode: packages.LoadSyntax, Tests: true}
+	cfg := &packages.Config{Mode: packages.LoadFiles, Tests: true, Dir: srcDir}
 	pkgs, err := packages.Load(cfg, "file="+source)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Sometimes mockgen needs to execute from outside Go modules. For example in [bazel_gomock](https://github.com/jmhodges/bazel_gomock) rule, mockgen is executed from the root of a Bazel repository, which may not be in any Go modules. `bazel_gomock` recently removed GOPATH from its runtime (https://github.com/jmhodges/bazel_gomock/pull/16), so GOPATH isn't available either. This PR sets the working directory of `packages.Load` to the source directory, which is guaranteed to be in a Go module or GOPATH.

This PR also decrease the load mode to `packages.LoadFiles` so it's faster and more resilient to errors that shouldn't affect mockgen.