### PR TITLE
Simplified Go code

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -269,7 +269,7 @@ func (g *generator) Generate(pkg *model.Package, pkgName string, outputPackagePa
 	}
 
 	// Sort keys to make import alias generation predictable
-	sortedPaths := make([]string, len(im), len(im))
+	sortedPaths := make([]string, len(im))
 	x := 0
 	for pth := range im {
 		sortedPaths[x] = pth

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -250,9 +250,7 @@ func (p *fileParser) parseInterface(name, pkg string, it *ast.InterfaceType) (*m
 			}
 			// Copy the methods.
 			// TODO: apply shadowing rules.
-			for _, m := range eintf.Methods {
-				intf.Methods = append(intf.Methods, m)
-			}
+			intf.Methods = append(intf.Methods, eintf.Methods...)
 		case *ast.SelectorExpr:
 			// Embedded interface in another package.
 			fpkg, sel := v.X.(*ast.Ident).String(), v.Sel.String()
@@ -278,9 +276,7 @@ func (p *fileParser) parseInterface(name, pkg string, it *ast.InterfaceType) (*m
 			}
 			// Copy the methods.
 			// TODO: apply shadowing rules.
-			for _, m := range eintf.Methods {
-				intf.Methods = append(intf.Methods, m)
-			}
+			intf.Methods = append(intf.Methods, eintf.Methods...)
 		default:
 			return nil, fmt.Errorf("don't know how to mock method of type %T", field.Type)
 		}


### PR DESCRIPTION
- Replaced range loops with an append
- No need to specify slice capacity that's equal to the length