### PR TITLE
Make error message clearer

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -301,8 +301,8 @@ func (c *Call) matches(args []interface{}) error {
 
 		for i, m := range c.args {
 			if !m.Matches(args[i]) {
-				return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-					c.origin, strconv.Itoa(i), args[i], m)
+				return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v(%v)\nWant: %v",
+					c.origin, strconv.Itoa(i), reflect.TypeOf(args[i]), args[i], m)
 			}
 		}
 	} else {
@@ -323,8 +323,8 @@ func (c *Call) matches(args []interface{}) error {
 			if i < c.methodType.NumIn()-1 {
 				// Non-variadic args
 				if !m.Matches(args[i]) {
-					return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-						c.origin, strconv.Itoa(i), args[i], m)
+					return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v(%v)\nWant: %v",
+						c.origin, strconv.Itoa(i), reflect.TypeOf(args[i]), args[i], m)
 				}
 				continue
 			}
@@ -366,8 +366,8 @@ func (c *Call) matches(args []interface{}) error {
 			// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD, matcherE)
 			// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, matcherC, matcherD)
 			// Got Foo(a, b, c) want Foo(matcherA, matcherB)
-			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
-				c.origin, strconv.Itoa(i), args[i:], c.args[i])
+			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v(%v)\nWant: %v(%v)",
+				c.origin, strconv.Itoa(i), reflect.TypeOf(args[i:]), args[i:], reflect.TypeOf(c.args[i]), c.args[i])
 
 		}
 	}

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -284,13 +284,13 @@ func TestUnexpectedArgValue_FirstArg(t *testing.T) {
 		// the method argument (of TestStruct type) has 1 unexpected value (for the Message field)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "no message"}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {123 no message}\nWant: is equal to {123 hello}")
+		"Got: gomock_test.TestStruct({123 no message})\nWant: is equal to gomock_test.TestStruct({123 hello})")
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 2 unexpected values (for both fields)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message"}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {11 no message}\nWant: is equal to {123 hello}")
+		"Got: gomock_test.TestStruct({11 no message})\nWant: is equal to gomock_test.TestStruct({123 hello})")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.
@@ -309,7 +309,7 @@ func TestUnexpectedArgValue_SecondArg(t *testing.T) {
 	reporter.assertFatal(func() {
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "hello"}, 3)
 	}, "Unexpected call to", "doesn't match the argument at index 1",
-		"Got: 3\nWant: is equal to 15")
+		"Got: int(3)\nWant: is equal to int(15)")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.
@@ -701,7 +701,7 @@ func TestVariadicNoMatch(t *testing.T) {
 	rep.assertFatal(func() {
 		ctrl.Call(s, "VariadicMethod", 1)
 	}, "Expected call at", "doesn't match the argument at index 0",
-		"Got: 1\nWant: is equal to 0")
+		"Got: int(1)\nWant: is equal to int(0)")
 	ctrl.Call(s, "VariadicMethod", 0)
 	ctrl.Finish()
 }

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -48,7 +48,7 @@ func (e eqMatcher) Matches(x interface{}) bool {
 }
 
 func (e eqMatcher) String() string {
-	return fmt.Sprintf("is equal to %v", e.x)
+	return fmt.Sprintf("is equal to %v(%v)", reflect.TypeOf(e.x), e.x)
 }
 
 type nilMatcher struct{}


### PR DESCRIPTION
Referring to [this](https://github.com/golang/mock/issues/190) issue.
Add data type on error message if the data type is not equal