### PR TITLE
Pass -build_flags as Multiple Args

### DIFF
--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"text/template"
 
 	"github.com/golang/mock/mockgen/model"
@@ -116,7 +117,7 @@ func runInDir(program []byte, dir string) (*model.Package, error) {
 	cmdArgs := []string{}
 	cmdArgs = append(cmdArgs, "build")
 	if *buildFlags != "" {
-		cmdArgs = append(cmdArgs, *buildFlags)
+		cmdArgs = append(cmdArgs, strings.Split(*buildFlags, " ")...)
 	}
 	cmdArgs = append(cmdArgs, "-o", progBinary, progSource)
 


### PR DESCRIPTION
Value of -build_flags was passed to 'go' as a single argument.
For example when passing -build_flags "-mod vendor", the invoked
commandline was `go -mod\ vendor` and the go command errored out because
there is no such arg.

That has caused confusion, e.g. in #296

Solve this by splitting the argument by a space.