### PR TITLE
Add Mockgen Version Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ contexts too.
 Installation
 ------------
 
-Once you have [installed Go][golang-install], install the `mockgen` tool:
+Once you have [installed Go][golang-install], install the `mockgen` tool.
+
+To get the latest released version use:
 
 ```bash
-go get github.com/golang/mock/mockgen
+GO111MODULE=on go get github.com/golang/mock/mockgen@latest
 ```
 
-_Note: It is recommended to have `GO111MODULE=on` to ensure the correct
-dependencies are used._
+If you use `mockgen` in your CI pipeline, it may be more appropriate to fixate
+on a specific mockgen version.
+
 
 Documentation
 -------------

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -53,11 +53,17 @@ var (
 	copyrightFile   = flag.String("copyright_file", "", "Copyright file used to add copyright header")
 
 	debugParser = flag.Bool("debug_parser", false, "Print out parser results only.")
+	version     = flag.Bool("version", false, "Print version.")
 )
 
 func main() {
 	flag.Usage = usage
 	flag.Parse()
+
+	if *version {
+		printVersion()
+		return
+	}
 
 	var pkg *model.Package
 	var err error

--- a/mockgen/version.1.11.go
+++ b/mockgen/version.1.11.go
@@ -1,4 +1,4 @@
-// Copyright 2010 Google Inc.
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mockgen/version.1.11.go
+++ b/mockgen/version.1.11.go
@@ -1,0 +1,26 @@
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.12
+
+package main
+
+import (
+	"log"
+)
+
+func printVersion() {
+	log.Printf("No version information is available for Mockgen compiled with " +
+		"version 1.11")
+}

--- a/mockgen/version.1.12.go
+++ b/mockgen/version.1.12.go
@@ -1,4 +1,4 @@
-// Copyright 2010 Google Inc.
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mockgen/version.1.12.go
+++ b/mockgen/version.1.12.go
@@ -1,0 +1,35 @@
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// +build go1.12
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"runtime/debug"
+)
+
+func printVersion() {
+	if bi, exists := debug.ReadBuildInfo(); exists {
+		fmt.Println(bi.Main.Version)
+	} else {
+		log.Printf("No version information found. Make sure to use " +
+			"GO111MODULE=on when running 'go get' in order to use specific " +
+			"version of the binary.")
+	}
+
+}


### PR DESCRIPTION
Add -version flag that shows a version provided by Go modules.

This strategy works well for module aware invocations of `go get` and `go
run` (which means using GO111MODULE=on).

If we ever plan to distribute built binaries, it is necessary to amend
the strategy with build flags.

GOPATH mode versioning is unsupported.