### PR TITLE
Allow AssignableToTypeOf reflect.Type

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -194,6 +194,12 @@ func Not(x interface{}) Matcher {
 //   var s fmt.Stringer = &bytes.Buffer{}
 //   AssignableToTypeOf(s).Matches(time.Second) // returns true
 //   AssignableToTypeOf(s).Matches(99) // returns false
+//
+//   var ctx = reflect.TypeOf((*context.Context)).Elem()
+//   AssignableToTypeOf(ctx).Matches(context.Background()) // returns true
 func AssignableToTypeOf(x interface{}) Matcher {
+	if xt, ok := x.(reflect.Type); ok {
+		return assignableToTypeOfMatcher{xt}
+	}
 	return assignableToTypeOfMatcher{reflect.TypeOf(x)}
 }

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -17,7 +17,9 @@
 package gomock_test
 
 import (
+	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -115,5 +117,15 @@ func TestAssignableToTypeOfMatcher(t *testing.T) {
 	}
 	if match := gomock.AssignableToTypeOf(&Dog{}).Matches(&Dog{Breed: "pug", Name: "Fido"}); !match {
 		t.Errorf(`AssignableToTypeOf(&Dog{}) should match &Dog{Breed: "pug", Name: "Fido"}`)
+	}
+
+	ctxInterface := reflect.TypeOf((*context.Context)(nil)).Elem()
+	if match := gomock.AssignableToTypeOf(ctxInterface).Matches(context.Background()); !match {
+		t.Errorf(`AssignableToTypeOf(context.Context) should not match context.Background()`)
+	}
+
+	ctxWithValue := context.WithValue(context.Background(), "key", "val")
+	if match := gomock.AssignableToTypeOf(ctxInterface).Matches(ctxWithValue); !match {
+		t.Errorf(`AssignableToTypeOf(context.Context) should not match ctxWithValue`)
 	}
 }


### PR DESCRIPTION
use case:

```go
package main

import (
	"context"
	"fmt"
	"reflect"

	"github.com/golang/mock/gomock"
)

func main() {
	ctx, cancel := context.WithCancel(context.Background())
	defer cancel()

	res := gomock.AssignableToTypeOf(context.Background()).Matches(ctx)
	fmt.Println(res) // fasle, but I want true!!

	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()

	res = gomock.AssignableToTypeOf(ctxType).Matches(ctx)
	fmt.Println(res) // true

	res = gomock.AssignableToTypeOf(ctxType).Matches(context.Background())
	fmt.Println(res) // true
}
```