### PR TITLE
refactor method names for reflect/source

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -62,13 +62,13 @@ func main() {
 	var pkg *model.Package
 	var err error
 	if *source != "" {
-		pkg, err = parseFile(*source)
+		pkg, err = sourceMode(*source)
 	} else {
 		if flag.NArg() != 2 {
 			usage()
 			log.Fatal("Expected exactly two arguments")
 		}
-		pkg, err = reflect(flag.Arg(0), strings.Split(flag.Arg(1), ","))
+		pkg, err = reflectMode(flag.Arg(0), strings.Split(flag.Arg(1), ","))
 	}
 	if err != nil {
 		log.Fatalf("Loading input failed: %v", err)
@@ -531,7 +531,7 @@ func (g *generator) getArgNames(m *model.Method) []string {
 	argNames := make([]string, len(m.In))
 	for i, p := range m.In {
 		name := p.Name
-		if name == "" {
+		if name == "" || name == "_" {
 			name = fmt.Sprintf("arg%d", i)
 		}
 		argNames[i] = name

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -267,3 +267,89 @@ func findMethod(t *testing.T, identifier, methodName string, lines []string) int
 	t.Fatalf("unable to find 'func (m %s) %s'", identifier, methodName)
 	panic("unreachable")
 }
+
+func TestGetArgNames(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		method   *model.Method
+		expected []string
+	}{
+		{
+			name: "NamedArg",
+			method: &model.Method{
+				In: []*model.Parameter{
+					{
+						Name: "firstArg",
+						Type: &model.NamedType{Type: "int"},
+					},
+					{
+						Name: "secondArg",
+						Type: &model.NamedType{Type: "string"},
+					},
+				},
+			},
+			expected: []string{"firstArg", "secondArg"},
+		},
+		{
+			name: "NotNamedArg",
+			method: &model.Method{
+				In: []*model.Parameter{
+					{
+						Name: "",
+						Type: &model.NamedType{Type: "int"},
+					},
+					{
+						Name: "",
+						Type: &model.NamedType{Type: "string"},
+					},
+				},
+			},
+			expected: []string{"arg0", "arg1"},
+		},
+		{
+			name: "MixedNameArg",
+			method: &model.Method{
+				In: []*model.Parameter{
+					{
+						Name: "firstArg",
+						Type: &model.NamedType{Type: "int"},
+					},
+					{
+						Name: "_",
+						Type: &model.NamedType{Type: "string"},
+					},
+				},
+			},
+			expected: []string{"firstArg", "arg1"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			g := generator{}
+
+			result := g.getArgNames(testCase.method)
+			if !testEqSliceStr(t, result, testCase.expected) {
+				t.Fatalf("expected %s, got %s", result, testCase.expected)
+			}
+		})
+	}
+}
+
+func testEqSliceStr(t *testing.T, a, b []string) bool {
+	t.Helper()
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -41,7 +41,8 @@ var (
 
 // TODO: simplify error reporting
 
-func parseFile(source string) (*model.Package, error) {
+// sourceMode generates mocks via source file.
+func sourceMode(source string) (*model.Package, error) {
 	srcDir, err := filepath.Abs(filepath.Dir(source))
 	if err != nil {
 		return nil, fmt.Errorf("failed getting source directory: %v", err)

--- a/mockgen/parse_test.go
+++ b/mockgen/parse_test.go
@@ -110,6 +110,6 @@ func checkGreeterImports(t *testing.T, imports map[string]string) {
 func Benchmark_parseFile(b *testing.B) {
 	source := "internal/tests/performance/big_interface/big_interface.go"
 	for n := 0; n < b.N; n++ {
-		parseFile(source)
+		sourceMode(source)
 	}
 }

--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -132,7 +132,8 @@ func runInDir(program []byte, dir string) (*model.Package, error) {
 	return run(filepath.Join(tmpDir, progBinary))
 }
 
-func reflect(importPath string, symbols []string) (*model.Package, error) {
+// reflectMode generates mocks via reflection on interfaces.
+func reflectMode(importPath string, symbols []string) (*model.Package, error) {
 	// TODO: sanity check arguments
 
 	if *execOnly != "" {


### PR DESCRIPTION
The reflect method should be renamed so it does not collide with
the reflect package name. As is, it makes import reflect in the
code non-idiomatic. Also renamed sourceMode to stay consistent.

Noticed this here: #371