### PR TITLE
Reflect in Current Directory First

### DIFF
--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -129,6 +129,7 @@ func runInDir(program []byte, dir string) (*model.Package, error) {
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
+
 	return run(filepath.Join(tmpDir, progBinary))
 }
 
@@ -152,6 +153,11 @@ func reflectMode(importPath string, symbols []string) (*model.Package, error) {
 
 	wd, _ := os.Getwd()
 
+	// Try to run the reflection program  in the current working directory.
+	if p, err := runInDir(program, wd); err == nil {
+		return p, nil
+	}
+
 	// Try to run the program in the same directory as the input package.
 	if p, err := build.Import(importPath, wd, build.FindOnly); err == nil {
 		dir := p.Dir
@@ -160,11 +166,7 @@ func reflectMode(importPath string, symbols []string) (*model.Package, error) {
 		}
 	}
 
-	// Since that didn't work, try to run it in the current working directory.
-	if p, err := runInDir(program, wd); err == nil {
-		return p, nil
-	}
-	// Since that didn't work, try to run it in a standard temp directory.
+	// Try to run it in a standard temp directory.
 	return runInDir(program, "")
 }
 


### PR DESCRIPTION
Fixes #354

**Description**
Reflect in Current Directory First
  
Some users have intention to run mockgen in a module aware directory with
version pinned to those in `go.mod`.
    
Always try to run reflect program in current working directory first.

More context about the root cause of the bug is in https://github.com/golang/mock/issues/354#issuecomment-577147113

**Submitter Checklist**
- [ ] Includes tests

**Reviewer Notes**
- [ ] The code flow looks good.
- [ ] Tests added.

**Release Notes**
