### PR TITLE
Improve performance of mock generation (#396)

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -304,11 +304,7 @@ func (g *generator) Generate(pkg *model.Package, outputPkgName string, outputPac
 	}
 	sort.Strings(sortedPaths)
 
-	var importPaths []string
-	for _, pth := range sortedPaths {
-		importPaths = append(importPaths, pth)
-	}
-	packagesName := createPackageMap(importPaths)
+	packagesName := createPackageMap(sortedPaths)
 
 	g.packageMap = make(map[string]string, len(im))
 	localNames := make(map[string]bool, len(im))
@@ -635,7 +631,7 @@ func createPackageMap(importPaths []string) map[string]string {
 		Name       string
 		ImportPath string
 	}
-	names := make(map[string]string)
+	pkgMap := make(map[string]string)
 	b := bytes.NewBuffer(nil)
 	args := []string{"list", "-json"}
 	args = append(args, importPaths...)
@@ -645,11 +641,13 @@ func createPackageMap(importPaths []string) map[string]string {
 	dec := json.NewDecoder(b)
 	for dec.More() {
 		err := dec.Decode(&pkg)
-		if err == nil {
-			names[pkg.ImportPath] = pkg.Name
+		if err != nil {
+			log.Printf("failed to decode 'go list' output: %v", err)
+			continue
 		}
+		pkgMap[pkg.ImportPath] = pkg.Name
 	}
-	return names
+	return pkgMap
 }
 
 func printVersion() {

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -335,29 +335,32 @@ func TestGetArgNames(t *testing.T) {
 	}
 }
 
-func Test_lookupPackagesName(t *testing.T) {
+func Test_createPackageMap(t *testing.T) {
 	tests := []struct {
+		name            string
 		importPath      string
 		wantPackageName string
-		shouldPresent   bool
+		wantOK          bool
 	}{
-		{"context", "context", true},
-		{"golang.org/x/tools/present", "present", true},
-		{"rsc.io/quote/v3", "quote", true},
-		{"this/should/not/work", "", false},
+		{"golang package", "context", "context", true},
+		{"third party", "golang.org/x/tools/present", "present", true},
+		{"modules", "rsc.io/quote/v3", "quote", true},
+		{"fail", "this/should/not/work", "", false},
 	}
-	importPaths := make([]string, 0)
+	var importPaths []string
 	for _, t := range tests {
 		importPaths = append(importPaths, t.importPath)
 	}
-	gotPackagesName := lookupPackagesName(importPaths)
+	packages := createPackageMap(importPaths)
 	for _, tt := range tests {
-		gotPackageName, gotOk := gotPackagesName[tt.importPath]
-		if gotPackageName != tt.wantPackageName {
-			t.Errorf("lookupPackagesName() gotPackageName = %v, wantPackageName = %v", gotPackageName, tt.wantPackageName)
-		}
-		if gotOk != tt.shouldPresent {
-			t.Errorf("lookupPackageName() gotOk = %v, shouldPresent = %v", gotOk, tt.shouldPresent)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			gotPackageName, gotOk := packages[tt.importPath]
+			if gotPackageName != tt.wantPackageName {
+				t.Errorf("createPackageMap() gotPackageName = %v, wantPackageName = %v", gotPackageName, tt.wantPackageName)
+			}
+			if gotOk != tt.wantOK {
+				t.Errorf("createPackageMap() gotOk = %v, wantOK = %v", gotOk, tt.wantOK)
+			}
+		})
 	}
 }

--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -335,30 +335,29 @@ func TestGetArgNames(t *testing.T) {
 	}
 }
 
-func Test_lookupPackageName(t *testing.T) {
-	type args struct {
-		importPath string
-	}
+func Test_lookupPackagesName(t *testing.T) {
 	tests := []struct {
-		name            string
 		importPath      string
 		wantPackageName string
-		wantOK          bool
+		shouldPresent   bool
 	}{
-		{"golang package", "context", "context", true},
-		{"third party", "golang.org/x/tools/present", "present", true},
-		{"modules", "rsc.io/quote/v3", "quote", true},
-		{"fail", "this/should/not/work", "", false},
+		{"context", "context", true},
+		{"golang.org/x/tools/present", "present", true},
+		{"rsc.io/quote/v3", "quote", true},
+		{"this/should/not/work", "", false},
 	}
+	importPaths := make([]string, 0)
+	for _, t := range tests {
+		importPaths = append(importPaths, t.importPath)
+	}
+	gotPackagesName := lookupPackagesName(importPaths)
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotPackageName, gotOk := lookupPackageName(tt.importPath)
-			if gotPackageName != tt.wantPackageName {
-				t.Errorf("lookupPackageName() gotPackageName = %v, wantPackageName %v", gotPackageName, tt.wantPackageName)
-			}
-			if gotOk != tt.wantOK {
-				t.Errorf("lookupPackageName() gotOk = %v, wantOK %v", gotOk, tt.wantOK)
-			}
-		})
+		gotPackageName, gotOk := gotPackagesName[tt.importPath]
+		if gotPackageName != tt.wantPackageName {
+			t.Errorf("lookupPackagesName() gotPackageName = %v, wantPackageName = %v", gotPackageName, tt.wantPackageName)
+		}
+		if gotOk != tt.shouldPresent {
+			t.Errorf("lookupPackageName() gotOk = %v, shouldPresent = %v", gotOk, tt.shouldPresent)
+		}
 	}
 }

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -432,6 +432,15 @@ func (p *fileParser) parseType(pkg string, typ ast.Expr) (model.Type, error) {
 // importsOfFile returns a map of package name to import path
 // of the imports in file.
 func importsOfFile(file *ast.File) (normalImports map[string]string, dotImports []string) {
+	importPaths := make([]string, 0)
+	for _, is := range file.Imports {
+		if is.Name != nil {
+			continue
+		}
+		importPath := is.Path.Value[1 : len(is.Path.Value)-1] // remove quotes
+		importPaths = append(importPaths, importPath)
+	}
+	packagesName := lookupPackagesName(importPaths)
 	normalImports = make(map[string]string)
 	dotImports = make([]string, 0)
 	for _, is := range file.Imports {
@@ -445,7 +454,7 @@ func importsOfFile(file *ast.File) (normalImports map[string]string, dotImports 
 			}
 			pkgName = is.Name.Name
 		} else {
-			pkg, ok := lookupPackageName(importPath)
+			pkg, ok := packagesName[importPath]
 			if !ok {
 				// Fallback to import path suffix. Note that this is uncertain.
 				_, last := path.Split(importPath)

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -432,7 +432,7 @@ func (p *fileParser) parseType(pkg string, typ ast.Expr) (model.Type, error) {
 // importsOfFile returns a map of package name to import path
 // of the imports in file.
 func importsOfFile(file *ast.File) (normalImports map[string]string, dotImports []string) {
-	importPaths := make([]string, 0)
+	var importPaths []string
 	for _, is := range file.Imports {
 		if is.Name != nil {
 			continue
@@ -440,7 +440,7 @@ func importsOfFile(file *ast.File) (normalImports map[string]string, dotImports 
 		importPath := is.Path.Value[1 : len(is.Path.Value)-1] // remove quotes
 		importPaths = append(importPaths, importPath)
 	}
-	packagesName := lookupPackagesName(importPaths)
+	packagesName := createPackageMap(importPaths)
 	normalImports = make(map[string]string)
 	dotImports = make([]string, 0)
 	for _, is := range file.Imports {


### PR DESCRIPTION
Fixes #396. This PR optimise resolving correct package name with `go list` command. Instead of calling `go list` for each import in file, now we do it for all imports in one call.

Time consuming by mockgen:

Source mode
```
(v1.4.0)
time ../mockgen -source user.go -destination mock_user/mock_user.go Index,Embed,Embedded
../mockgen -source user.go -destination mock_user/mock_user.go   2.09s user 2.83s system 280% cpu 1.756 total
(with optimizations)
time ../mockgen -source user.go -destination mock_user/mock_user.go Index,Embed,Embedded
../mockgen -source user.go -destination mock_user/mock_user.go   0.54s user 0.63s system 320% cpu 0.364 total
```

Reflection mode
```
(v1.4.0)
time ../mockgen -destination mock_user/mock_user.go github.com/golang/mock/sample Index,Embed,Embedded
../mockgen -destination mock_user/mock_user.go  Index,Embed,Embedded  1.73s user 1.72s system 199% cpu 1.731 total
(with optimizations)
time ../mockgen -destination mock_user/mock_user.go github.com/golang/mock/sample Index,Embed,Embedded
../mockgen -destination mock_user/mock_user.go github.com/golang/mock/sample  0.96s user 0.53s system 153% cpu 0.972 total
```