### PR TITLE
mockgen: don't ignore stdout.Write error

### DIFF
--- a/mockgen/reflect.go
+++ b/mockgen/reflect.go
@@ -147,7 +147,9 @@ func reflectMode(importPath string, symbols []string) (*model.Package, error) {
 	}
 
 	if *progOnly {
-		_, _ = os.Stdout.Write(program)
+		if _, err := os.Stdout.Write(program); err != nil {
+			return nil, err
+		}
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
**Description**
Fixes: #411 
I am running into an issue when using `mockgen`'s `-prog_only` flag where an empty file is returned, but the program still exits with 0. I suspect this is because `os.Stdout.Write`'s error is being ignored.

**Submitter Checklist**

- [ ] Includes tests

**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Tests added.

**Release Notes**

n/a