### PR TITLE
Add a period to the end of comments

### DIFF
--- a/gomock/internal/mock_gomock/mock_matcher.go
+++ b/gomock/internal/mock_gomock/mock_matcher.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockMatcher is a mock of Matcher interface
+// MockMatcher is a mock of Matcher interface.
 type MockMatcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockMatcherMockRecorder
 }
 
-// MockMatcherMockRecorder is the mock recorder for MockMatcher
+// MockMatcherMockRecorder is the mock recorder for MockMatcher.
 type MockMatcherMockRecorder struct {
 	mock *MockMatcher
 }
 
-// NewMockMatcher creates a new mock instance
+// NewMockMatcher creates a new mock instance.
 func NewMockMatcher(ctrl *gomock.Controller) *MockMatcher {
 	mock := &MockMatcher{ctrl: ctrl}
 	mock.recorder = &MockMatcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMatcher) EXPECT() *MockMatcherMockRecorder {
 	return m.recorder
 }
 
-// Matches mocks base method
+// Matches mocks base method.
 func (m *MockMatcher) Matches(arg0 interface{}) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Matches", arg0)
@@ -40,13 +40,13 @@ func (m *MockMatcher) Matches(arg0 interface{}) bool {
 	return ret0
 }
 
-// Matches indicates an expected call of Matches
+// Matches indicates an expected call of Matches.
 func (mr *MockMatcherMockRecorder) Matches(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Matches", reflect.TypeOf((*MockMatcher)(nil).Matches), arg0)
 }
 
-// String mocks base method
+// String mocks base method.
 func (m *MockMatcher) String() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "String")
@@ -54,7 +54,7 @@ func (m *MockMatcher) String() string {
 	return ret0
 }
 
-// String indicates an expected call of String
+// String indicates an expected call of String.
 func (mr *MockMatcherMockRecorder) String() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockMatcher)(nil).String))

--- a/mockgen/internal/tests/aux_imports_embedded_interface/bugreport_mock.go
+++ b/mockgen/internal/tests/aux_imports_embedded_interface/bugreport_mock.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockSource is a mock of Source interface
+// MockSource is a mock of Source interface.
 type MockSource struct {
 	ctrl     *gomock.Controller
 	recorder *MockSourceMockRecorder
 }
 
-// MockSourceMockRecorder is the mock recorder for MockSource
+// MockSourceMockRecorder is the mock recorder for MockSource.
 type MockSourceMockRecorder struct {
 	mock *MockSource
 }
 
-// NewMockSource creates a new mock instance
+// NewMockSource creates a new mock instance.
 func NewMockSource(ctrl *gomock.Controller) *MockSource {
 	mock := &MockSource{ctrl: ctrl}
 	mock.recorder = &MockSourceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSource) EXPECT() *MockSourceMockRecorder {
 	return m.recorder
 }
 
-// Method mocks base method
+// Method mocks base method.
 func (m *MockSource) Method() faux.Return {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Method")
@@ -41,7 +41,7 @@ func (m *MockSource) Method() faux.Return {
 	return ret0
 }
 
-// Method indicates an expected call of Method
+// Method indicates an expected call of Method.
 func (mr *MockSourceMockRecorder) Method() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Method", reflect.TypeOf((*MockSource)(nil).Method))

--- a/mockgen/internal/tests/copyright_file/mock.go
+++ b/mockgen/internal/tests/copyright_file/mock.go
@@ -15,25 +15,25 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockEmpty is a mock of Empty interface
+// MockEmpty is a mock of Empty interface.
 type MockEmpty struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmptyMockRecorder
 }
 
-// MockEmptyMockRecorder is the mock recorder for MockEmpty
+// MockEmptyMockRecorder is the mock recorder for MockEmpty.
 type MockEmptyMockRecorder struct {
 	mock *MockEmpty
 }
 
-// NewMockEmpty creates a new mock instance
+// NewMockEmpty creates a new mock instance.
 func NewMockEmpty(ctrl *gomock.Controller) *MockEmpty {
 	mock := &MockEmpty{ctrl: ctrl}
 	mock.recorder = &MockEmptyMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmpty) EXPECT() *MockEmptyMockRecorder {
 	return m.recorder
 }

--- a/mockgen/internal/tests/custom_package_name/greeter/greeter_mock_test.go
+++ b/mockgen/internal/tests/custom_package_name/greeter/greeter_mock_test.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockInputMaker is a mock of InputMaker interface
+// MockInputMaker is a mock of InputMaker interface.
 type MockInputMaker struct {
 	ctrl     *gomock.Controller
 	recorder *MockInputMakerMockRecorder
 }
 
-// MockInputMakerMockRecorder is the mock recorder for MockInputMaker
+// MockInputMakerMockRecorder is the mock recorder for MockInputMaker.
 type MockInputMakerMockRecorder struct {
 	mock *MockInputMaker
 }
 
-// NewMockInputMaker creates a new mock instance
+// NewMockInputMaker creates a new mock instance.
 func NewMockInputMaker(ctrl *gomock.Controller) *MockInputMaker {
 	mock := &MockInputMaker{ctrl: ctrl}
 	mock.recorder = &MockInputMakerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInputMaker) EXPECT() *MockInputMakerMockRecorder {
 	return m.recorder
 }
 
-// MakeInput mocks base method
+// MakeInput mocks base method.
 func (m *MockInputMaker) MakeInput() client.GreetInput {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MakeInput")
@@ -41,7 +41,7 @@ func (m *MockInputMaker) MakeInput() client.GreetInput {
 	return ret0
 }
 
-// MakeInput indicates an expected call of MakeInput
+// MakeInput indicates an expected call of MakeInput.
 func (mr *MockInputMakerMockRecorder) MakeInput() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeInput", reflect.TypeOf((*MockInputMaker)(nil).MakeInput))

--- a/mockgen/internal/tests/dot_imports/mock.go
+++ b/mockgen/internal/tests/dot_imports/mock.go
@@ -12,30 +12,30 @@ import (
 	reflect "reflect"
 )
 
-// MockWithDotImports is a mock of WithDotImports interface
+// MockWithDotImports is a mock of WithDotImports interface.
 type MockWithDotImports struct {
 	ctrl     *gomock.Controller
 	recorder *MockWithDotImportsMockRecorder
 }
 
-// MockWithDotImportsMockRecorder is the mock recorder for MockWithDotImports
+// MockWithDotImportsMockRecorder is the mock recorder for MockWithDotImports.
 type MockWithDotImportsMockRecorder struct {
 	mock *MockWithDotImports
 }
 
-// NewMockWithDotImports creates a new mock instance
+// NewMockWithDotImports creates a new mock instance.
 func NewMockWithDotImports(ctrl *gomock.Controller) *MockWithDotImports {
 	mock := &MockWithDotImports{ctrl: ctrl}
 	mock.recorder = &MockWithDotImportsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockWithDotImports) EXPECT() *MockWithDotImportsMockRecorder {
 	return m.recorder
 }
 
-// Method1 mocks base method
+// Method1 mocks base method.
 func (m *MockWithDotImports) Method1() Request {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Method1")
@@ -43,13 +43,13 @@ func (m *MockWithDotImports) Method1() Request {
 	return ret0
 }
 
-// Method1 indicates an expected call of Method1
+// Method1 indicates an expected call of Method1.
 func (mr *MockWithDotImportsMockRecorder) Method1() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Method1", reflect.TypeOf((*MockWithDotImports)(nil).Method1))
 }
 
-// Method2 mocks base method
+// Method2 mocks base method.
 func (m *MockWithDotImports) Method2() *bytes.Buffer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Method2")
@@ -57,13 +57,13 @@ func (m *MockWithDotImports) Method2() *bytes.Buffer {
 	return ret0
 }
 
-// Method2 indicates an expected call of Method2
+// Method2 indicates an expected call of Method2.
 func (mr *MockWithDotImportsMockRecorder) Method2() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Method2", reflect.TypeOf((*MockWithDotImports)(nil).Method2))
 }
 
-// Method3 mocks base method
+// Method3 mocks base method.
 func (m *MockWithDotImports) Method3() Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Method3")
@@ -71,7 +71,7 @@ func (m *MockWithDotImports) Method3() Context {
 	return ret0
 }
 
-// Method3 indicates an expected call of Method3
+// Method3 indicates an expected call of Method3.
 func (mr *MockWithDotImportsMockRecorder) Method3() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Method3", reflect.TypeOf((*MockWithDotImports)(nil).Method3))

--- a/mockgen/internal/tests/empty_interface/mock.go
+++ b/mockgen/internal/tests/empty_interface/mock.go
@@ -8,25 +8,25 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockEmpty is a mock of Empty interface
+// MockEmpty is a mock of Empty interface.
 type MockEmpty struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmptyMockRecorder
 }
 
-// MockEmptyMockRecorder is the mock recorder for MockEmpty
+// MockEmptyMockRecorder is the mock recorder for MockEmpty.
 type MockEmptyMockRecorder struct {
 	mock *MockEmpty
 }
 
-// NewMockEmpty creates a new mock instance
+// NewMockEmpty creates a new mock instance.
 func NewMockEmpty(ctrl *gomock.Controller) *MockEmpty {
 	mock := &MockEmpty{ctrl: ctrl}
 	mock.recorder = &MockEmptyMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmpty) EXPECT() *MockEmptyMockRecorder {
 	return m.recorder
 }

--- a/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
+++ b/mockgen/internal/tests/generated_identifier_conflict/bugreport_mock.go
@@ -9,42 +9,42 @@ import (
 	reflect "reflect"
 )
 
-// MockExample is a mock of Example interface
+// MockExample is a mock of Example interface.
 type MockExample struct {
 	ctrl     *gomock.Controller
 	recorder *MockExampleMockRecorder
 }
 
-// MockExampleMockRecorder is the mock recorder for MockExample
+// MockExampleMockRecorder is the mock recorder for MockExample.
 type MockExampleMockRecorder struct {
 	mock *MockExample
 }
 
-// NewMockExample creates a new mock instance
+// NewMockExample creates a new mock instance.
 func NewMockExample(ctrl *gomock.Controller) *MockExample {
 	mock := &MockExample{ctrl: ctrl}
 	mock.recorder = &MockExampleMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExample) EXPECT() *MockExampleMockRecorder {
 	return m.recorder
 }
 
-// Method mocks base method
+// Method mocks base method.
 func (m_2 *MockExample) Method(_m, _mr, m, mr int) {
 	m_2.ctrl.T.Helper()
 	m_2.ctrl.Call(m_2, "Method", _m, _mr, m, mr)
 }
 
-// Method indicates an expected call of Method
+// Method indicates an expected call of Method.
 func (mr_2 *MockExampleMockRecorder) Method(_m, _mr, m, mr interface{}) *gomock.Call {
 	mr_2.mock.ctrl.T.Helper()
 	return mr_2.mock.ctrl.RecordCallWithMethodType(mr_2.mock, "Method", reflect.TypeOf((*MockExample)(nil).Method), _m, _mr, m, mr)
 }
 
-// VarargMethod mocks base method
+// VarargMethod mocks base method.
 func (m *MockExample) VarargMethod(_s, _x, a, ret int, varargs ...int) {
 	m.ctrl.T.Helper()
 	varargs_2 := []interface{}{_s, _x, a, ret}
@@ -54,7 +54,7 @@ func (m *MockExample) VarargMethod(_s, _x, a, ret int, varargs ...int) {
 	m.ctrl.Call(m, "VarargMethod", varargs_2...)
 }
 
-// VarargMethod indicates an expected call of VarargMethod
+// VarargMethod indicates an expected call of VarargMethod.
 func (mr *MockExampleMockRecorder) VarargMethod(_s, _x, a, ret interface{}, varargs ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs_2 := append([]interface{}{_s, _x, a, ret}, varargs...)

--- a/mockgen/internal/tests/import_source/definition/source_mock.go
+++ b/mockgen/internal/tests/import_source/definition/source_mock.go
@@ -9,36 +9,36 @@ import (
 	reflect "reflect"
 )
 
-// MockS is a mock of S interface
+// MockS is a mock of S interface.
 type MockS struct {
 	ctrl     *gomock.Controller
 	recorder *MockSMockRecorder
 }
 
-// MockSMockRecorder is the mock recorder for MockS
+// MockSMockRecorder is the mock recorder for MockS.
 type MockSMockRecorder struct {
 	mock *MockS
 }
 
-// NewMockS creates a new mock instance
+// NewMockS creates a new mock instance.
 func NewMockS(ctrl *gomock.Controller) *MockS {
 	mock := &MockS{ctrl: ctrl}
 	mock.recorder = &MockSMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockS) EXPECT() *MockSMockRecorder {
 	return m.recorder
 }
 
-// F mocks base method
+// F mocks base method.
 func (m *MockS) F(arg0 X) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "F", arg0)
 }
 
-// F indicates an expected call of F
+// F indicates an expected call of F.
 func (mr *MockSMockRecorder) F(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "F", reflect.TypeOf((*MockS)(nil).F), arg0)

--- a/mockgen/internal/tests/import_source/source_mock.go
+++ b/mockgen/internal/tests/import_source/source_mock.go
@@ -10,36 +10,36 @@ import (
 	reflect "reflect"
 )
 
-// MockS is a mock of S interface
+// MockS is a mock of S interface.
 type MockS struct {
 	ctrl     *gomock.Controller
 	recorder *MockSMockRecorder
 }
 
-// MockSMockRecorder is the mock recorder for MockS
+// MockSMockRecorder is the mock recorder for MockS.
 type MockSMockRecorder struct {
 	mock *MockS
 }
 
-// NewMockS creates a new mock instance
+// NewMockS creates a new mock instance.
 func NewMockS(ctrl *gomock.Controller) *MockS {
 	mock := &MockS{ctrl: ctrl}
 	mock.recorder = &MockSMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockS) EXPECT() *MockSMockRecorder {
 	return m.recorder
 }
 
-// F mocks base method
+// F mocks base method.
 func (m *MockS) F(arg0 source.X) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "F", arg0)
 }
 
-// F indicates an expected call of F
+// F indicates an expected call of F.
 func (mr *MockSMockRecorder) F(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "F", reflect.TypeOf((*MockS)(nil).F), arg0)

--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/mock.go
+++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/reflect_output/mock.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockIntf is a mock of Intf interface
+// MockIntf is a mock of Intf interface.
 type MockIntf struct {
 	ctrl     *gomock.Controller
 	recorder *MockIntfMockRecorder
 }
 
-// MockIntfMockRecorder is the mock recorder for MockIntf
+// MockIntfMockRecorder is the mock recorder for MockIntf.
 type MockIntfMockRecorder struct {
 	mock *MockIntf
 }
 
-// NewMockIntf creates a new mock instance
+// NewMockIntf creates a new mock instance.
 func NewMockIntf(ctrl *gomock.Controller) *MockIntf {
 	mock := &MockIntf{ctrl: ctrl}
 	mock.recorder = &MockIntfMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIntf) EXPECT() *MockIntfMockRecorder {
 	return m.recorder
 }
 
-// F mocks base method
+// F mocks base method.
 func (m *MockIntf) F() pkg.Arg {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "F")
@@ -41,7 +41,7 @@ func (m *MockIntf) F() pkg.Arg {
 	return ret0
 }
 
-// F indicates an expected call of F
+// F indicates an expected call of F.
 func (mr *MockIntfMockRecorder) F() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "F", reflect.TypeOf((*MockIntf)(nil).F))

--- a/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/mock.go
+++ b/mockgen/internal/tests/internal_pkg/subdir/internal/pkg/source_output/mock.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockArg is a mock of Arg interface
+// MockArg is a mock of Arg interface.
 type MockArg struct {
 	ctrl     *gomock.Controller
 	recorder *MockArgMockRecorder
 }
 
-// MockArgMockRecorder is the mock recorder for MockArg
+// MockArgMockRecorder is the mock recorder for MockArg.
 type MockArgMockRecorder struct {
 	mock *MockArg
 }
 
-// NewMockArg creates a new mock instance
+// NewMockArg creates a new mock instance.
 func NewMockArg(ctrl *gomock.Controller) *MockArg {
 	mock := &MockArg{ctrl: ctrl}
 	mock.recorder = &MockArgMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockArg) EXPECT() *MockArgMockRecorder {
 	return m.recorder
 }
 
-// Foo mocks base method
+// Foo mocks base method.
 func (m *MockArg) Foo() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Foo")
@@ -41,36 +41,36 @@ func (m *MockArg) Foo() int {
 	return ret0
 }
 
-// Foo indicates an expected call of Foo
+// Foo indicates an expected call of Foo.
 func (mr *MockArgMockRecorder) Foo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Foo", reflect.TypeOf((*MockArg)(nil).Foo))
 }
 
-// MockIntf is a mock of Intf interface
+// MockIntf is a mock of Intf interface.
 type MockIntf struct {
 	ctrl     *gomock.Controller
 	recorder *MockIntfMockRecorder
 }
 
-// MockIntfMockRecorder is the mock recorder for MockIntf
+// MockIntfMockRecorder is the mock recorder for MockIntf.
 type MockIntfMockRecorder struct {
 	mock *MockIntf
 }
 
-// NewMockIntf creates a new mock instance
+// NewMockIntf creates a new mock instance.
 func NewMockIntf(ctrl *gomock.Controller) *MockIntf {
 	mock := &MockIntf{ctrl: ctrl}
 	mock.recorder = &MockIntfMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIntf) EXPECT() *MockIntfMockRecorder {
 	return m.recorder
 }
 
-// F mocks base method
+// F mocks base method.
 func (m *MockIntf) F() pkg.Arg {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "F")
@@ -78,7 +78,7 @@ func (m *MockIntf) F() pkg.Arg {
 	return ret0
 }
 
-// F indicates an expected call of F
+// F indicates an expected call of F.
 func (mr *MockIntfMockRecorder) F() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "F", reflect.TypeOf((*MockIntf)(nil).F))

--- a/mockgen/internal/tests/mock_in_test_package/mock_test.go
+++ b/mockgen/internal/tests/mock_in_test_package/mock_test.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockFinder is a mock of Finder interface
+// MockFinder is a mock of Finder interface.
 type MockFinder struct {
 	ctrl     *gomock.Controller
 	recorder *MockFinderMockRecorder
 }
 
-// MockFinderMockRecorder is the mock recorder for MockFinder
+// MockFinderMockRecorder is the mock recorder for MockFinder.
 type MockFinderMockRecorder struct {
 	mock *MockFinder
 }
 
-// NewMockFinder creates a new mock instance
+// NewMockFinder creates a new mock instance.
 func NewMockFinder(ctrl *gomock.Controller) *MockFinder {
 	mock := &MockFinder{ctrl: ctrl}
 	mock.recorder = &MockFinderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 	return m.recorder
 }
 
-// FindUser mocks base method
+// FindUser mocks base method.
 func (m *MockFinder) FindUser(name string) mock_in_test_package.User {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindUser", name)
@@ -41,19 +41,19 @@ func (m *MockFinder) FindUser(name string) mock_in_test_package.User {
 	return ret0
 }
 
-// FindUser indicates an expected call of FindUser
+// FindUser indicates an expected call of FindUser.
 func (mr *MockFinderMockRecorder) FindUser(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUser", reflect.TypeOf((*MockFinder)(nil).FindUser), name)
 }
 
-// Add mocks base method
+// Add mocks base method.
 func (m *MockFinder) Add(u mock_in_test_package.User) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Add", u)
 }
 
-// Add indicates an expected call of Add
+// Add indicates an expected call of Add.
 func (mr *MockFinderMockRecorder) Add(u interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockFinder)(nil).Add), u)

--- a/mockgen/internal/tests/self_package/mock.go
+++ b/mockgen/internal/tests/self_package/mock.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockMethods is a mock of Methods interface
+// MockMethods is a mock of Methods interface.
 type MockMethods struct {
 	ctrl     *gomock.Controller
 	recorder *MockMethodsMockRecorder
 }
 
-// MockMethodsMockRecorder is the mock recorder for MockMethods
+// MockMethodsMockRecorder is the mock recorder for MockMethods.
 type MockMethodsMockRecorder struct {
 	mock *MockMethods
 }
 
-// NewMockMethods creates a new mock instance
+// NewMockMethods creates a new mock instance.
 func NewMockMethods(ctrl *gomock.Controller) *MockMethods {
 	mock := &MockMethods{ctrl: ctrl}
 	mock.recorder = &MockMethodsMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMethods) EXPECT() *MockMethodsMockRecorder {
 	return m.recorder
 }
 
-// getInfo mocks base method
+// getInfo mocks base method.
 func (m *MockMethods) getInfo() Info {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getInfo")
@@ -40,7 +40,7 @@ func (m *MockMethods) getInfo() Info {
 	return ret0
 }
 
-// getInfo indicates an expected call of getInfo
+// getInfo indicates an expected call of getInfo.
 func (mr *MockMethodsMockRecorder) getInfo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getInfo", reflect.TypeOf((*MockMethods)(nil).getInfo))

--- a/mockgen/internal/tests/test_package/mock_test.go
+++ b/mockgen/internal/tests/test_package/mock_test.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockFinder is a mock of Finder interface
+// MockFinder is a mock of Finder interface.
 type MockFinder struct {
 	ctrl     *gomock.Controller
 	recorder *MockFinderMockRecorder
 }
 
-// MockFinderMockRecorder is the mock recorder for MockFinder
+// MockFinderMockRecorder is the mock recorder for MockFinder.
 type MockFinderMockRecorder struct {
 	mock *MockFinder
 }
 
-// NewMockFinder creates a new mock instance
+// NewMockFinder creates a new mock instance.
 func NewMockFinder(ctrl *gomock.Controller) *MockFinder {
 	mock := &MockFinder{ctrl: ctrl}
 	mock.recorder = &MockFinderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 	return m.recorder
 }
 
-// FindUser mocks base method
+// FindUser mocks base method.
 func (m *MockFinder) FindUser(name string) User {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindUser", name)
@@ -40,19 +40,19 @@ func (m *MockFinder) FindUser(name string) User {
 	return ret0
 }
 
-// FindUser indicates an expected call of FindUser
+// FindUser indicates an expected call of FindUser.
 func (mr *MockFinderMockRecorder) FindUser(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindUser", reflect.TypeOf((*MockFinder)(nil).FindUser), name)
 }
 
-// Add mocks base method
+// Add mocks base method.
 func (m *MockFinder) Add(u User) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Add", u)
 }
 
-// Add indicates an expected call of Add
+// Add indicates an expected call of Add.
 func (mr *MockFinderMockRecorder) Add(u interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockFinder)(nil).Add), u)

--- a/mockgen/internal/tests/unexported_method/bugreport_mock.go
+++ b/mockgen/internal/tests/unexported_method/bugreport_mock.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockExample is a mock of Example interface
+// MockExample is a mock of Example interface.
 type MockExample struct {
 	ctrl     *gomock.Controller
 	recorder *MockExampleMockRecorder
 }
 
-// MockExampleMockRecorder is the mock recorder for MockExample
+// MockExampleMockRecorder is the mock recorder for MockExample.
 type MockExampleMockRecorder struct {
 	mock *MockExample
 }
 
-// NewMockExample creates a new mock instance
+// NewMockExample creates a new mock instance.
 func NewMockExample(ctrl *gomock.Controller) *MockExample {
 	mock := &MockExample{ctrl: ctrl}
 	mock.recorder = &MockExampleMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockExample) EXPECT() *MockExampleMockRecorder {
 	return m.recorder
 }
 
-// someMethod mocks base method
+// someMethod mocks base method.
 func (m *MockExample) someMethod(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "someMethod", arg0)
@@ -40,7 +40,7 @@ func (m *MockExample) someMethod(arg0 string) string {
 	return ret0
 }
 
-// someMethod indicates an expected call of someMethod
+// someMethod indicates an expected call of someMethod.
 func (mr *MockExampleMockRecorder) someMethod(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "someMethod", reflect.TypeOf((*MockExample)(nil).someMethod), arg0)

--- a/mockgen/internal/tests/vendor_dep/mock.go
+++ b/mockgen/internal/tests/vendor_dep/mock.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockVendorsDep is a mock of VendorsDep interface
+// MockVendorsDep is a mock of VendorsDep interface.
 type MockVendorsDep struct {
 	ctrl     *gomock.Controller
 	recorder *MockVendorsDepMockRecorder
 }
 
-// MockVendorsDepMockRecorder is the mock recorder for MockVendorsDep
+// MockVendorsDepMockRecorder is the mock recorder for MockVendorsDep.
 type MockVendorsDepMockRecorder struct {
 	mock *MockVendorsDep
 }
 
-// NewMockVendorsDep creates a new mock instance
+// NewMockVendorsDep creates a new mock instance.
 func NewMockVendorsDep(ctrl *gomock.Controller) *MockVendorsDep {
 	mock := &MockVendorsDep{ctrl: ctrl}
 	mock.recorder = &MockVendorsDepMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockVendorsDep) EXPECT() *MockVendorsDepMockRecorder {
 	return m.recorder
 }
 
-// Foo mocks base method
+// Foo mocks base method.
 func (m *MockVendorsDep) Foo() present.Elem {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Foo")
@@ -41,7 +41,7 @@ func (m *MockVendorsDep) Foo() present.Elem {
 	return ret0
 }
 
-// Foo indicates an expected call of Foo
+// Foo indicates an expected call of Foo.
 func (mr *MockVendorsDepMockRecorder) Foo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Foo", reflect.TypeOf((*MockVendorsDep)(nil).Foo))

--- a/mockgen/internal/tests/vendor_dep/source_mock_package/mock.go
+++ b/mockgen/internal/tests/vendor_dep/source_mock_package/mock.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockVendorsDep is a mock of VendorsDep interface
+// MockVendorsDep is a mock of VendorsDep interface.
 type MockVendorsDep struct {
 	ctrl     *gomock.Controller
 	recorder *MockVendorsDepMockRecorder
 }
 
-// MockVendorsDepMockRecorder is the mock recorder for MockVendorsDep
+// MockVendorsDepMockRecorder is the mock recorder for MockVendorsDep.
 type MockVendorsDepMockRecorder struct {
 	mock *MockVendorsDep
 }
 
-// NewMockVendorsDep creates a new mock instance
+// NewMockVendorsDep creates a new mock instance.
 func NewMockVendorsDep(ctrl *gomock.Controller) *MockVendorsDep {
 	mock := &MockVendorsDep{ctrl: ctrl}
 	mock.recorder = &MockVendorsDepMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockVendorsDep) EXPECT() *MockVendorsDepMockRecorder {
 	return m.recorder
 }
 
-// Foo mocks base method
+// Foo mocks base method.
 func (m *MockVendorsDep) Foo() present.Elem {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Foo")
@@ -41,7 +41,7 @@ func (m *MockVendorsDep) Foo() present.Elem {
 	return ret0
 }
 
-// Foo indicates an expected call of Foo
+// Foo indicates an expected call of Foo.
 func (mr *MockVendorsDepMockRecorder) Foo() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Foo", reflect.TypeOf((*MockVendorsDep)(nil).Foo))

--- a/mockgen/internal/tests/vendor_pkg/mock.go
+++ b/mockgen/internal/tests/vendor_pkg/mock.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockElem is a mock of Elem interface
+// MockElem is a mock of Elem interface.
 type MockElem struct {
 	ctrl     *gomock.Controller
 	recorder *MockElemMockRecorder
 }
 
-// MockElemMockRecorder is the mock recorder for MockElem
+// MockElemMockRecorder is the mock recorder for MockElem.
 type MockElemMockRecorder struct {
 	mock *MockElem
 }
 
-// NewMockElem creates a new mock instance
+// NewMockElem creates a new mock instance.
 func NewMockElem(ctrl *gomock.Controller) *MockElem {
 	mock := &MockElem{ctrl: ctrl}
 	mock.recorder = &MockElemMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockElem) EXPECT() *MockElemMockRecorder {
 	return m.recorder
 }
 
-// TemplateName mocks base method
+// TemplateName mocks base method.
 func (m *MockElem) TemplateName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TemplateName")
@@ -40,7 +40,7 @@ func (m *MockElem) TemplateName() string {
 	return ret0
 }
 
-// TemplateName indicates an expected call of TemplateName
+// TemplateName indicates an expected call of TemplateName.
 func (mr *MockElemMockRecorder) TemplateName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemplateName", reflect.TypeOf((*MockElem)(nil).TemplateName))

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -376,7 +376,7 @@ func (g *generator) GenerateMockInterface(intf *model.Interface, outputPackagePa
 	mockType := g.mockName(intf.Name)
 
 	g.p("")
-	g.p("// %v is a mock of %v interface", mockType, intf.Name)
+	g.p("// %v is a mock of %v interface.", mockType, intf.Name)
 	g.p("type %v struct {", mockType)
 	g.in()
 	g.p("ctrl     *gomock.Controller")
@@ -385,7 +385,7 @@ func (g *generator) GenerateMockInterface(intf *model.Interface, outputPackagePa
 	g.p("}")
 	g.p("")
 
-	g.p("// %vMockRecorder is the mock recorder for %v", mockType, mockType)
+	g.p("// %vMockRecorder is the mock recorder for %v.", mockType, mockType)
 	g.p("type %vMockRecorder struct {", mockType)
 	g.in()
 	g.p("mock *%v", mockType)
@@ -398,7 +398,7 @@ func (g *generator) GenerateMockInterface(intf *model.Interface, outputPackagePa
 	// g.p("var _ %v = (*%v)(nil)", typeName, mockType)
 	// g.p("")
 
-	g.p("// New%v creates a new mock instance", mockType)
+	g.p("// New%v creates a new mock instance.", mockType)
 	g.p("func New%v(ctrl *gomock.Controller) *%v {", mockType, mockType)
 	g.in()
 	g.p("mock := &%v{ctrl: ctrl}", mockType)
@@ -409,7 +409,7 @@ func (g *generator) GenerateMockInterface(intf *model.Interface, outputPackagePa
 	g.p("")
 
 	// XXX: possible name collision here if someone has EXPECT in their interface.
-	g.p("// EXPECT returns an object that allows the caller to indicate expected use")
+	g.p("// EXPECT returns an object that allows the caller to indicate expected use.")
 	g.p("func (m *%v) EXPECT() *%vMockRecorder {", mockType, mockType)
 	g.in()
 	g.p("return m.recorder")
@@ -465,7 +465,7 @@ func (g *generator) GenerateMockMethod(mockType string, m *model.Method, pkgOver
 	ia := newIdentifierAllocator(argNames)
 	idRecv := ia.allocateIdentifier("m")
 
-	g.p("// %v mocks base method", m.Name)
+	g.p("// %v mocks base method.", m.Name)
 	g.p("func (%v *%v) %v(%v)%v {", idRecv, mockType, m.Name, argString, retString)
 	g.in()
 	g.p("%s.ctrl.T.Helper()", idRecv)
@@ -533,7 +533,7 @@ func (g *generator) GenerateMockRecorderMethod(mockType string, m *model.Method)
 	ia := newIdentifierAllocator(argNames)
 	idRecv := ia.allocateIdentifier("mr")
 
-	g.p("// %v indicates an expected call of %v", m.Name, m.Name)
+	g.p("// %v indicates an expected call of %v.", m.Name, m.Name)
 	g.p("func (%s *%vMockRecorder) %v(%v) *gomock.Call {", idRecv, mockType, m.Name, argString)
 	g.in()
 	g.p("%s.mock.ctrl.T.Helper()", idRecv)

--- a/sample/concurrent/mock/concurrent_mock.go
+++ b/sample/concurrent/mock/concurrent_mock.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockMath is a mock of Math interface
+// MockMath is a mock of Math interface.
 type MockMath struct {
 	ctrl     *gomock.Controller
 	recorder *MockMathMockRecorder
 }
 
-// MockMathMockRecorder is the mock recorder for MockMath
+// MockMathMockRecorder is the mock recorder for MockMath.
 type MockMathMockRecorder struct {
 	mock *MockMath
 }
 
-// NewMockMath creates a new mock instance
+// NewMockMath creates a new mock instance.
 func NewMockMath(ctrl *gomock.Controller) *MockMath {
 	mock := &MockMath{ctrl: ctrl}
 	mock.recorder = &MockMathMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMath) EXPECT() *MockMathMockRecorder {
 	return m.recorder
 }
 
-// Sum mocks base method
+// Sum mocks base method.
 func (m *MockMath) Sum(arg0, arg1 int) int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sum", arg0, arg1)
@@ -40,7 +40,7 @@ func (m *MockMath) Sum(arg0, arg1 int) int {
 	return ret0
 }
 
-// Sum indicates an expected call of Sum
+// Sum indicates an expected call of Sum.
 func (mr *MockMathMockRecorder) Sum(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sum", reflect.TypeOf((*MockMath)(nil).Sum), arg0, arg1)

--- a/sample/mock_user/mock_user.go
+++ b/sample/mock_user/mock_user.go
@@ -20,54 +20,54 @@ import (
 	template0 "text/template"
 )
 
-// MockIndex is a mock of Index interface
+// MockIndex is a mock of Index interface.
 type MockIndex struct {
 	ctrl     *gomock.Controller
 	recorder *MockIndexMockRecorder
 }
 
-// MockIndexMockRecorder is the mock recorder for MockIndex
+// MockIndexMockRecorder is the mock recorder for MockIndex.
 type MockIndexMockRecorder struct {
 	mock *MockIndex
 }
 
-// NewMockIndex creates a new mock instance
+// NewMockIndex creates a new mock instance.
 func NewMockIndex(ctrl *gomock.Controller) *MockIndex {
 	mock := &MockIndex{ctrl: ctrl}
 	mock.recorder = &MockIndexMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockIndex) EXPECT() *MockIndexMockRecorder {
 	return m.recorder
 }
 
-// Anon mocks base method
+// Anon mocks base method.
 func (m *MockIndex) Anon(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Anon", arg0)
 }
 
-// Anon indicates an expected call of Anon
+// Anon indicates an expected call of Anon.
 func (mr *MockIndexMockRecorder) Anon(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Anon", reflect.TypeOf((*MockIndex)(nil).Anon), arg0)
 }
 
-// Chan mocks base method
+// Chan mocks base method.
 func (m *MockIndex) Chan(arg0 chan int, arg1 chan<- hash.Hash) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Chan", arg0, arg1)
 }
 
-// Chan indicates an expected call of Chan
+// Chan indicates an expected call of Chan.
 func (mr *MockIndexMockRecorder) Chan(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Chan", reflect.TypeOf((*MockIndex)(nil).Chan), arg0, arg1)
 }
 
-// ConcreteRet mocks base method
+// ConcreteRet mocks base method.
 func (m *MockIndex) ConcreteRet() chan<- bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConcreteRet")
@@ -75,13 +75,13 @@ func (m *MockIndex) ConcreteRet() chan<- bool {
 	return ret0
 }
 
-// ConcreteRet indicates an expected call of ConcreteRet
+// ConcreteRet indicates an expected call of ConcreteRet.
 func (mr *MockIndexMockRecorder) ConcreteRet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConcreteRet", reflect.TypeOf((*MockIndex)(nil).ConcreteRet))
 }
 
-// Ellip mocks base method
+// Ellip mocks base method.
 func (m *MockIndex) Ellip(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -91,14 +91,14 @@ func (m *MockIndex) Ellip(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Ellip", varargs...)
 }
 
-// Ellip indicates an expected call of Ellip
+// Ellip indicates an expected call of Ellip.
 func (mr *MockIndexMockRecorder) Ellip(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ellip", reflect.TypeOf((*MockIndex)(nil).Ellip), varargs...)
 }
 
-// EllipOnly mocks base method
+// EllipOnly mocks base method.
 func (m *MockIndex) EllipOnly(arg0 ...string) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -108,73 +108,73 @@ func (m *MockIndex) EllipOnly(arg0 ...string) {
 	m.ctrl.Call(m, "EllipOnly", varargs...)
 }
 
-// EllipOnly indicates an expected call of EllipOnly
+// EllipOnly indicates an expected call of EllipOnly.
 func (mr *MockIndexMockRecorder) EllipOnly(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EllipOnly", reflect.TypeOf((*MockIndex)(nil).EllipOnly), arg0...)
 }
 
-// ForeignFour mocks base method
+// ForeignFour mocks base method.
 func (m *MockIndex) ForeignFour(arg0 imp_four.Imp4) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ForeignFour", arg0)
 }
 
-// ForeignFour indicates an expected call of ForeignFour
+// ForeignFour indicates an expected call of ForeignFour.
 func (mr *MockIndexMockRecorder) ForeignFour(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignFour", reflect.TypeOf((*MockIndex)(nil).ForeignFour), arg0)
 }
 
-// ForeignOne mocks base method
+// ForeignOne mocks base method.
 func (m *MockIndex) ForeignOne(arg0 imp1.Imp1) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ForeignOne", arg0)
 }
 
-// ForeignOne indicates an expected call of ForeignOne
+// ForeignOne indicates an expected call of ForeignOne.
 func (mr *MockIndexMockRecorder) ForeignOne(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignOne", reflect.TypeOf((*MockIndex)(nil).ForeignOne), arg0)
 }
 
-// ForeignThree mocks base method
+// ForeignThree mocks base method.
 func (m *MockIndex) ForeignThree(arg0 imp3.Imp3) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ForeignThree", arg0)
 }
 
-// ForeignThree indicates an expected call of ForeignThree
+// ForeignThree indicates an expected call of ForeignThree.
 func (mr *MockIndexMockRecorder) ForeignThree(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignThree", reflect.TypeOf((*MockIndex)(nil).ForeignThree), arg0)
 }
 
-// ForeignTwo mocks base method
+// ForeignTwo mocks base method.
 func (m *MockIndex) ForeignTwo(arg0 imp2.Imp2) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ForeignTwo", arg0)
 }
 
-// ForeignTwo indicates an expected call of ForeignTwo
+// ForeignTwo indicates an expected call of ForeignTwo.
 func (mr *MockIndexMockRecorder) ForeignTwo(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignTwo", reflect.TypeOf((*MockIndex)(nil).ForeignTwo), arg0)
 }
 
-// Func mocks base method
+// Func mocks base method.
 func (m *MockIndex) Func(arg0 func(http.Request) (int, bool)) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Func", arg0)
 }
 
-// Func indicates an expected call of Func
+// Func indicates an expected call of Func.
 func (mr *MockIndexMockRecorder) Func(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Func", reflect.TypeOf((*MockIndex)(nil).Func), arg0)
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockIndex) Get(arg0 string) interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
@@ -182,13 +182,13 @@ func (m *MockIndex) Get(arg0 string) interface{} {
 	return ret0
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockIndexMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockIndex)(nil).Get), arg0)
 }
 
-// GetTwo mocks base method
+// GetTwo mocks base method.
 func (m *MockIndex) GetTwo(arg0, arg1 string) (interface{}, interface{}) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTwo", arg0, arg1)
@@ -197,25 +197,25 @@ func (m *MockIndex) GetTwo(arg0, arg1 string) (interface{}, interface{}) {
 	return ret0, ret1
 }
 
-// GetTwo indicates an expected call of GetTwo
+// GetTwo indicates an expected call of GetTwo.
 func (mr *MockIndexMockRecorder) GetTwo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTwo", reflect.TypeOf((*MockIndex)(nil).GetTwo), arg0, arg1)
 }
 
-// Map mocks base method
+// Map mocks base method.
 func (m *MockIndex) Map(arg0 map[int]hash.Hash) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Map", arg0)
 }
 
-// Map indicates an expected call of Map
+// Map indicates an expected call of Map.
 func (mr *MockIndexMockRecorder) Map(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Map", reflect.TypeOf((*MockIndex)(nil).Map), arg0)
 }
 
-// NillableRet mocks base method
+// NillableRet mocks base method.
 func (m *MockIndex) NillableRet() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NillableRet")
@@ -223,13 +223,13 @@ func (m *MockIndex) NillableRet() error {
 	return ret0
 }
 
-// NillableRet indicates an expected call of NillableRet
+// NillableRet indicates an expected call of NillableRet.
 func (mr *MockIndexMockRecorder) NillableRet() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NillableRet", reflect.TypeOf((*MockIndex)(nil).NillableRet))
 }
 
-// Other mocks base method
+// Other mocks base method.
 func (m *MockIndex) Other() hash.Hash {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Other")
@@ -237,37 +237,37 @@ func (m *MockIndex) Other() hash.Hash {
 	return ret0
 }
 
-// Other indicates an expected call of Other
+// Other indicates an expected call of Other.
 func (mr *MockIndexMockRecorder) Other() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Other", reflect.TypeOf((*MockIndex)(nil).Other))
 }
 
-// Ptr mocks base method
+// Ptr mocks base method.
 func (m *MockIndex) Ptr(arg0 *int) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Ptr", arg0)
 }
 
-// Ptr indicates an expected call of Ptr
+// Ptr indicates an expected call of Ptr.
 func (mr *MockIndexMockRecorder) Ptr(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ptr", reflect.TypeOf((*MockIndex)(nil).Ptr), arg0)
 }
 
-// Put mocks base method
+// Put mocks base method.
 func (m *MockIndex) Put(arg0 string, arg1 interface{}) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Put", arg0, arg1)
 }
 
-// Put indicates an expected call of Put
+// Put indicates an expected call of Put.
 func (mr *MockIndexMockRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockIndex)(nil).Put), arg0, arg1)
 }
 
-// Slice mocks base method
+// Slice mocks base method.
 func (m *MockIndex) Slice(arg0 []int, arg1 []byte) [3]int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Slice", arg0, arg1)
@@ -275,96 +275,96 @@ func (m *MockIndex) Slice(arg0 []int, arg1 []byte) [3]int {
 	return ret0
 }
 
-// Slice indicates an expected call of Slice
+// Slice indicates an expected call of Slice.
 func (mr *MockIndexMockRecorder) Slice(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Slice", reflect.TypeOf((*MockIndex)(nil).Slice), arg0, arg1)
 }
 
-// Struct mocks base method
+// Struct mocks base method.
 func (m *MockIndex) Struct(arg0 struct{}) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Struct", arg0)
 }
 
-// Struct indicates an expected call of Struct
+// Struct indicates an expected call of Struct.
 func (mr *MockIndexMockRecorder) Struct(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Struct", reflect.TypeOf((*MockIndex)(nil).Struct), arg0)
 }
 
-// StructChan mocks base method
+// StructChan mocks base method.
 func (m *MockIndex) StructChan(arg0 chan struct{}) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StructChan", arg0)
 }
 
-// StructChan indicates an expected call of StructChan
+// StructChan indicates an expected call of StructChan.
 func (mr *MockIndexMockRecorder) StructChan(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StructChan", reflect.TypeOf((*MockIndex)(nil).StructChan), arg0)
 }
 
-// Summary mocks base method
+// Summary mocks base method.
 func (m *MockIndex) Summary(arg0 *bytes.Buffer, arg1 io.Writer) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Summary", arg0, arg1)
 }
 
-// Summary indicates an expected call of Summary
+// Summary indicates an expected call of Summary.
 func (mr *MockIndexMockRecorder) Summary(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Summary", reflect.TypeOf((*MockIndex)(nil).Summary), arg0, arg1)
 }
 
-// Templates mocks base method
+// Templates mocks base method.
 func (m *MockIndex) Templates(arg0 template.CSS, arg1 template0.FuncMap) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Templates", arg0, arg1)
 }
 
-// Templates indicates an expected call of Templates
+// Templates indicates an expected call of Templates.
 func (mr *MockIndexMockRecorder) Templates(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Templates", reflect.TypeOf((*MockIndex)(nil).Templates), arg0, arg1)
 }
 
-// MockEmbed is a mock of Embed interface
+// MockEmbed is a mock of Embed interface.
 type MockEmbed struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmbedMockRecorder
 }
 
-// MockEmbedMockRecorder is the mock recorder for MockEmbed
+// MockEmbedMockRecorder is the mock recorder for MockEmbed.
 type MockEmbedMockRecorder struct {
 	mock *MockEmbed
 }
 
-// NewMockEmbed creates a new mock instance
+// NewMockEmbed creates a new mock instance.
 func NewMockEmbed(ctrl *gomock.Controller) *MockEmbed {
 	mock := &MockEmbed{ctrl: ctrl}
 	mock.recorder = &MockEmbedMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmbed) EXPECT() *MockEmbedMockRecorder {
 	return m.recorder
 }
 
-// EmbeddedMethod mocks base method
+// EmbeddedMethod mocks base method.
 func (m *MockEmbed) EmbeddedMethod() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "EmbeddedMethod")
 }
 
-// EmbeddedMethod indicates an expected call of EmbeddedMethod
+// EmbeddedMethod indicates an expected call of EmbeddedMethod.
 func (mr *MockEmbedMockRecorder) EmbeddedMethod() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmbeddedMethod", reflect.TypeOf((*MockEmbed)(nil).EmbeddedMethod))
 }
 
-// ForeignEmbeddedMethod mocks base method
+// ForeignEmbeddedMethod mocks base method.
 func (m *MockEmbed) ForeignEmbeddedMethod() *bufio.Reader {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ForeignEmbeddedMethod")
@@ -372,66 +372,66 @@ func (m *MockEmbed) ForeignEmbeddedMethod() *bufio.Reader {
 	return ret0
 }
 
-// ForeignEmbeddedMethod indicates an expected call of ForeignEmbeddedMethod
+// ForeignEmbeddedMethod indicates an expected call of ForeignEmbeddedMethod.
 func (mr *MockEmbedMockRecorder) ForeignEmbeddedMethod() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForeignEmbeddedMethod", reflect.TypeOf((*MockEmbed)(nil).ForeignEmbeddedMethod))
 }
 
-// ImplicitPackage mocks base method
+// ImplicitPackage mocks base method.
 func (m *MockEmbed) ImplicitPackage(arg0 string, arg1 imp1.ImpT, arg2 []imp1.ImpT, arg3 *imp1.ImpT, arg4 chan imp1.ImpT) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "ImplicitPackage", arg0, arg1, arg2, arg3, arg4)
 }
 
-// ImplicitPackage indicates an expected call of ImplicitPackage
+// ImplicitPackage indicates an expected call of ImplicitPackage.
 func (mr *MockEmbedMockRecorder) ImplicitPackage(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImplicitPackage", reflect.TypeOf((*MockEmbed)(nil).ImplicitPackage), arg0, arg1, arg2, arg3, arg4)
 }
 
-// RegularMethod mocks base method
+// RegularMethod mocks base method.
 func (m *MockEmbed) RegularMethod() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RegularMethod")
 }
 
-// RegularMethod indicates an expected call of RegularMethod
+// RegularMethod indicates an expected call of RegularMethod.
 func (mr *MockEmbedMockRecorder) RegularMethod() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegularMethod", reflect.TypeOf((*MockEmbed)(nil).RegularMethod))
 }
 
-// MockEmbedded is a mock of Embedded interface
+// MockEmbedded is a mock of Embedded interface.
 type MockEmbedded struct {
 	ctrl     *gomock.Controller
 	recorder *MockEmbeddedMockRecorder
 }
 
-// MockEmbeddedMockRecorder is the mock recorder for MockEmbedded
+// MockEmbeddedMockRecorder is the mock recorder for MockEmbedded.
 type MockEmbeddedMockRecorder struct {
 	mock *MockEmbedded
 }
 
-// NewMockEmbedded creates a new mock instance
+// NewMockEmbedded creates a new mock instance.
 func NewMockEmbedded(ctrl *gomock.Controller) *MockEmbedded {
 	mock := &MockEmbedded{ctrl: ctrl}
 	mock.recorder = &MockEmbeddedMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEmbedded) EXPECT() *MockEmbeddedMockRecorder {
 	return m.recorder
 }
 
-// EmbeddedMethod mocks base method
+// EmbeddedMethod mocks base method.
 func (m *MockEmbedded) EmbeddedMethod() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "EmbeddedMethod")
 }
 
-// EmbeddedMethod indicates an expected call of EmbeddedMethod
+// EmbeddedMethod indicates an expected call of EmbeddedMethod.
 func (mr *MockEmbeddedMockRecorder) EmbeddedMethod() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EmbeddedMethod", reflect.TypeOf((*MockEmbedded)(nil).EmbeddedMethod))


### PR DESCRIPTION
**Description**

Added a period to the end of all declaration comments according to [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences):

> Comments should begin with the name of the thing being described and end in a period

Actual code changes are only in ` mockgen/mockgen.go`. Other changes are just tests.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests

**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Tests added.

**Release Notes**

```
- Added period to the end of generated comments.
```
