### PR TITLE
Using pacakges.NeedName

### DIFF
--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -548,7 +548,11 @@ func packageNameOfDir(srcDir string) (string, error) {
 
 // parseImportPackage get package import path via source file
 func parsePackageImport(source, srcDir string) (string, error) {
-	cfg := &packages.Config{Mode: packages.LoadFiles, Tests: true, Dir: srcDir}
+	cfg := &packages.Config{
+		Mode:  packages.NeedName,
+		Tests: true,
+		Dir:   srcDir,
+	}
 	pkgs, err := packages.Load(cfg, "file="+source)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
**Description**

`packages.LoadFiles` is [deprecated](https://pkg.go.dev/golang.org/x/tools/go/packages?tab=doc#pkg-constants). It is not future-proof to use it. In addition, I found all mockgen need is `Package.PkgPath`, so `packages.NeedName` is sufficient.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests

**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Tests added.
