### PR TITLE
support embedded error interface in source mode

### DIFF
--- a/mockgen/internal/tests/aux_imports_embedded_interface/bugreport_mock.go
+++ b/mockgen/internal/tests/aux_imports_embedded_interface/bugreport_mock.go
@@ -46,3 +46,17 @@ func (mr *MockSourceMockRecorder) Method() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Method", reflect.TypeOf((*MockSource)(nil).Method))
 }
+
+// Error mocks base method.
+func (m *MockSource) Error() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Error")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Error indicates an expected call of Error.
+func (mr *MockSourceMockRecorder) Error() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockSource)(nil).Error))
+}

--- a/mockgen/internal/tests/aux_imports_embedded_interface/faux/faux.go
+++ b/mockgen/internal/tests/aux_imports_embedded_interface/faux/faux.go
@@ -3,6 +3,7 @@ package faux
 type Foreign interface {
 	Method() Return
 	Embedded
+	error
 }
 
 type Embedded interface{}

--- a/mockgen/internal/tests/import_embedded_interface/bugreport.go
+++ b/mockgen/internal/tests/import_embedded_interface/bugreport.go
@@ -27,6 +27,7 @@ import (
 type Source interface {
 	ersatz.Embedded
 	faux.Foreign
+	error
 }
 
 func CallForeignMethod(s Source) {

--- a/mockgen/internal/tests/import_embedded_interface/bugreport_mock.go
+++ b/mockgen/internal/tests/import_embedded_interface/bugreport_mock.go
@@ -61,3 +61,17 @@ func (mr *MockSourceMockRecorder) OtherErsatz() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OtherErsatz", reflect.TypeOf((*MockSource)(nil).OtherErsatz))
 }
+
+// Error mocks base method.
+func (m *MockSource) Error() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Error")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Error indicates an expected call of Error.
+func (mr *MockSourceMockRecorder) Error() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockSource)(nil).Error))
+}

--- a/mockgen/model/model.go
+++ b/mockgen/model/model.go
@@ -468,3 +468,19 @@ func impPath(imp string) string {
 	}
 	return imp
 }
+
+// ErrorInterface represent built-in error interface.
+var ErrorInterface = Interface{
+	Name: "error",
+	Methods: []*Method{
+		{
+			Name: "Error",
+			Out: []*Parameter{
+				{
+					Name: "",
+					Type: PredeclaredType("string"),
+				},
+			},
+		},
+	},
+}

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -272,13 +272,23 @@ func (p *fileParser) parseInterface(name, pkg string, it *ast.InterfaceType) (*m
 			// Embedded interface in this package.
 			ei := p.auxInterfaces[pkg][v.String()]
 			if ei == nil {
-				if ei = p.importedInterfaces[pkg][v.String()]; ei == nil {
+				ei = p.importedInterfaces[pkg][v.String()]
+			}
+
+			var eintf *model.Interface
+			if ei != nil {
+				var err error
+				eintf, err = p.parseInterface(v.String(), pkg, ei)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// This is built-in error interface.
+				if v.String() == model.ErrorInterface.Name {
+					eintf = &model.ErrorInterface
+				} else {
 					return nil, p.errorf(v.Pos(), "unknown embedded interface %s", v.String())
 				}
-			}
-			eintf, err := p.parseInterface(v.String(), pkg, ei)
-			if err != nil {
-				return nil, err
 			}
 			// Copy the methods.
 			// TODO: apply shadowing rules.


### PR DESCRIPTION
example: 


new a interface:  
```go
type NotFound interface {
	error
	NotFound()
}
```

execute `mockgen -source xxx.go`