### PR TITLE
add reset method

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -256,6 +256,13 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	return rets
 }
 
+// Reset rest expectedCalls
+func (ctrl *Controller) Reset() {
+	ctrl.mu.Lock()
+	defer ctrl.mu.Unlock()
+	ctrl.expectedCalls = newCallSet()
+}
+
 // Finish checks to see if all the methods that were expected to be called
 // were called. It should be invoked for each Controller. It is not idempotent
 // and therefore can only be invoked once.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Add a `Reset` method for cases where I have to reuse `Controller` 



**Description**

when use `gomock` for a integration testing scenario, where the testing programing depends on lots of grpc interface, I can not just renew a Controller for each case , so a `reset` method is needed


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests

**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Improved API for custom matchers
```
