### PR TITLE
check error for os.Setenv in parse_test.go

### DIFF
--- a/mockgen/parse_test.go
+++ b/mockgen/parse_test.go
@@ -167,8 +167,7 @@ func TestParsePackageImport(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			for key, value := range testCase.envs {
-				err = os.Setenv(key, value)
-				if err != nil {
+				if err := os.Setenv(key, value); err != nil {
 					t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 				}
 			}
@@ -200,14 +199,12 @@ func TestParsePackageImport_FallbackGoPath(t *testing.T) {
 	}
 	key := "GOPATH"
 	value := goPath
-	err = os.Setenv(key, value)
-	if err != nil {
+	if err := os.Setenv(key, value); err != nil {
 		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
 	key = "GO111MODULE"
 	value = "on"
-	err = os.Setenv(key, value)
-	if err != nil {
+	if err := os.Setenv(key, value); err != nil {
 		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
 	pkgPath, err := parsePackageImport(srcDir)
@@ -252,14 +249,12 @@ func TestParsePackageImport_FallbackMultiGoPath(t *testing.T) {
 	goPaths := strings.Join(goPathList, string(os.PathListSeparator))
 	key := "GOPATH"
 	value := goPaths
-	err = os.Setenv(key, value)
-	if err != nil {
+	if err := os.Setenv(key, value); err != nil {
 		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
 	key = "GO111MODULE"
 	value = "on"
-	err = os.Setenv(key, value)
-	if err != nil {
+	if err := os.Setenv(key, value); err != nil {
 		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
 	pkgPath, err := parsePackageImport(srcDir)

--- a/mockgen/parse_test.go
+++ b/mockgen/parse_test.go
@@ -169,7 +169,7 @@ func TestParsePackageImport(t *testing.T) {
 			for key, value := range testCase.envs {
 				err = os.Setenv(key, value)
 				if err != nil {
-					t.Errorf("unexpected error: %s", err.Error())
+					t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 				}
 			}
 			pkgPath, err := parsePackageImport(filepath.Clean(testCase.dir))
@@ -198,13 +198,17 @@ func TestParsePackageImport_FallbackGoPath(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = os.Setenv("GOPATH", goPath)
+	key := "GOPATH"
+	value := goPath
+	err = os.Setenv(key, value)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
+		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
-	err = os.Setenv("GO111MODULE", "on")
+	key = "GO111MODULE"
+	value = "on"
+	err = os.Setenv(key, value)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
+		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
 	pkgPath, err := parsePackageImport(srcDir)
 	expected := "example.com/foo"
@@ -246,13 +250,17 @@ func TestParsePackageImport_FallbackMultiGoPath(t *testing.T) {
 	}()
 
 	goPaths := strings.Join(goPathList, string(os.PathListSeparator))
-	err = os.Setenv("GOPATH", goPaths)
+	key := "GOPATH"
+	value := goPaths
+	err = os.Setenv(key, value)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
+		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
-	err = os.Setenv("GO111MODULE", "on")
+	key = "GO111MODULE"
+	value = "on"
+	err = os.Setenv(key, value)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err.Error())
+		t.Fatalf("unable to set environment variable %q to %q: %v", key, value, err)
 	}
 	pkgPath, err := parsePackageImport(srcDir)
 	expected := "example.com/foo"

--- a/mockgen/parse_test.go
+++ b/mockgen/parse_test.go
@@ -167,7 +167,10 @@ func TestParsePackageImport(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			for key, value := range testCase.envs {
-				os.Setenv(key, value)
+				err = os.Setenv(key, value)
+				if err != nil {
+					t.Errorf("unexpected error: %s", err.Error())
+				}
 			}
 			pkgPath, err := parsePackageImport(filepath.Clean(testCase.dir))
 			if err != testCase.err {
@@ -195,8 +198,14 @@ func TestParsePackageImport_FallbackGoPath(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	os.Setenv("GOPATH", goPath)
-	os.Setenv("GO111MODULE", "on")
+	err = os.Setenv("GOPATH", goPath)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	err = os.Setenv("GO111MODULE", "on")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
 	pkgPath, err := parsePackageImport(srcDir)
 	expected := "example.com/foo"
 	if pkgPath != expected {
@@ -237,8 +246,14 @@ func TestParsePackageImport_FallbackMultiGoPath(t *testing.T) {
 	}()
 
 	goPaths := strings.Join(goPathList, string(os.PathListSeparator))
-	os.Setenv("GOPATH", goPaths)
-	os.Setenv("GO111MODULE", "on")
+	err = os.Setenv("GOPATH", goPaths)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	err = os.Setenv("GO111MODULE", "on")
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
 	pkgPath, err := parsePackageImport(srcDir)
 	expected := "example.com/foo"
 	if pkgPath != expected {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Found some missing error checks for the `os.SetEnv()` method in `mockgen/parse_test.go`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests

**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Tests added.


**Release Notes**

/

Fixes: #473