### PR TITLE
Introduce ctrl.Continue() to allow reuse of controller

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -256,6 +256,13 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	return rets
 }
 
+// ResetCalls - Reset expectedCalls
+func (ctrl *Controller) ResetCalls() {
+	ctrl.mu.Lock()
+	defer ctrl.mu.Unlock()
+	ctrl.expectedCalls = newCallSet()
+}
+
 // Finish checks to see if all the methods that were expected to be called
 // were called. It should be invoked for each Controller. It is not idempotent
 // and therefore can only be invoked once.

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -256,9 +256,9 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	return rets
 }
 
-// ResetExpectedCalls Reset expectedCalls so that we can reuse the same controller to define
+// Reset expectedCalls so that we can reuse the same controller to define
 // new set of expected calls. See https://github.com/golang/mock/issues/459
-func (ctrl *Controller) ResetExpectedCalls() {
+func (ctrl *Controller) reset() {
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 	ctrl.expectedCalls = newCallSet()
@@ -314,7 +314,7 @@ func (ctrl *Controller) Continue() {
 	defer ctrl.mu.Unlock()
 
 	if ctrl.finished {
-		ctrl.T.Fatalf("Controller.Continue was called after ctrl.Finish. It has to be called before ctrl.Finish.")
+		ctrl.T.Fatalf("Controller.Continue was called after ctrl.Finish. It has to be called before ctrl.Finish when you want to reuse the controller.")
 		return
 	}
 
@@ -332,6 +332,9 @@ func (ctrl *Controller) Continue() {
 	if len(failures) != 0 {
 		ctrl.T.Fatalf("aborting test due to missing call(s)")
 	}
+
+	// Reset the calls
+	ctrl.reset()
 }
 
 // callerInfo returns the file:line of the call site. skip is the number

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -296,9 +296,9 @@ func (ctrl *Controller) Finish() {
 
 // Continue is same as Finish with the following fundamental differences.
 // 1. It can be called multiple times by the user code.
-// 2. It doesn't set finished to true but instead checks if finished has been called. If it was called, it errors
-// out.
+// 2. Errors out if finished has already been called
 // 3. It checks whether all the expected calls are satisfied. If not, it calls Fatalf
+// 4. If all expected calls are satisfied then it resets the callset at the end.
 func (ctrl *Controller) Continue() {
 	ctrl.T.Helper()
 

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -256,8 +256,9 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	return rets
 }
 
-// ResetCalls - Reset expectedCalls
-func (ctrl *Controller) ResetCalls() {
+// ResetExpectedCalls Reset expectedCalls so that we can reuse the same controller to define
+// new set of expected calls. See https://github.com/golang/mock/issues/459
+func (ctrl *Controller) ResetExpectedCalls() {
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 	ctrl.expectedCalls = newCallSet()

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -256,14 +256,6 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	return rets
 }
 
-// Reset expectedCalls so that we can reuse the same controller to define
-// new set of expected calls. See https://github.com/golang/mock/issues/459
-func (ctrl *Controller) reset() {
-	ctrl.mu.Lock()
-	defer ctrl.mu.Unlock()
-	ctrl.expectedCalls = newCallSet()
-}
-
 // Finish checks to see if all the methods that were expected to be called
 // were called. It should be invoked for each Controller. It is not idempotent
 // and therefore can only be invoked once.
@@ -333,8 +325,9 @@ func (ctrl *Controller) Continue() {
 		ctrl.T.Fatalf("aborting test due to missing call(s)")
 	}
 
-	// Reset the calls
-	ctrl.reset()
+	// Reset expectedCalls so that we can reuse the same controller to define
+	// new set of expected calls. See https://github.com/golang/mock/issues/459
+	ctrl.expectedCalls = newCallSet()
 }
 
 // callerInfo returns the file:line of the call site. skip is the number

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -816,27 +816,7 @@ func TestWithHelper(t *testing.T) {
 	}
 }
 
-func TestContinue_call_multiple_times(t *testing.T) {
-	// It doesn't throw an error when expected call is made
-	reporter, ctrl := createFixtures(t)
-	subject := new(Subject)
-	ctrl.RecordCall(subject, "FooMethod", "argument").Times(1)
-	ctrl.Call(subject, "FooMethod", "argument")
-	ctrl.Continue()
-
-	// It fails when Continue is called again without calling Reset
-	reporter.assertFatal(func() {
-		ctrl.Continue()
-	})
-
-	ctrl.Reset()
-
-	// It doesn't fail when Continue is called again after calling reset
-	ctrl.Continue()
-}
-
-func TestContinue_called_after_finish(t *testing.T) {
-	// It doesn't throw an error when expected call is made
+func TestContinueThrowsErrorAfterCallingFinish(t *testing.T) {
 	reporter, ctrl := createFixtures(t)
 	subject := new(Subject)
 	ctrl.RecordCall(subject, "FooMethod", "argument").Times(1)
@@ -848,4 +828,3 @@ func TestContinue_called_after_finish(t *testing.T) {
 		ctrl.Continue()
 	})
 }
-

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -815,3 +815,37 @@ func TestWithHelper(t *testing.T) {
 		t.Fatal("expected Helper to be invoked")
 	}
 }
+
+func TestContinue_call_multiple_times(t *testing.T) {
+	// It doesn't throw an error when expected call is made
+	reporter, ctrl := createFixtures(t)
+	subject := new(Subject)
+	ctrl.RecordCall(subject, "FooMethod", "argument").Times(1)
+	ctrl.Call(subject, "FooMethod", "argument")
+	ctrl.Continue()
+
+	// It fails when Continue is called again without calling Reset
+	reporter.assertFatal(func() {
+		ctrl.Continue()
+	})
+
+	ctrl.Reset()
+
+	// It doesn't fail when Continue is called again after calling reset
+	ctrl.Continue()
+}
+
+func TestContinue_called_after_finish(t *testing.T) {
+	// It doesn't throw an error when expected call is made
+	reporter, ctrl := createFixtures(t)
+	subject := new(Subject)
+	ctrl.RecordCall(subject, "FooMethod", "argument").Times(1)
+	ctrl.Call(subject, "FooMethod", "argument")
+	ctrl.Finish()
+
+	// It fails when Continue is called after calling Finish
+	reporter.assertFatal(func() {
+		ctrl.Continue()
+	})
+}
+

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/golang/mock/gomock"
+	mock_user "github.com/golang/mock/sample/mock_user"
 )
 
 type ErrorReporter struct {
@@ -827,4 +828,39 @@ func TestContinueThrowsErrorAfterCallingFinish(t *testing.T) {
 	reporter.assertFatal(func() {
 		ctrl.Continue()
 	})
+}
+
+func TestContinueWithSubTests(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockIndex := mock_user.NewMockIndex(ctrl)
+
+	tests := []struct {
+		desc        string
+		name        string
+		calledTimes int
+	}{{
+		desc:        "Test for Ed",
+		name:        "Ed",
+		calledTimes: 1,
+	}, {
+		desc:        "Test for Edd",
+		name:        "Edd",
+		calledTimes: 2,
+	}, {
+		desc:        "Test for Eddy",
+		name:        "Eddy",
+		calledTimes: 3,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			defer ctrl.Continue()
+			mockIndex.EXPECT().Anon(test.name).Times(test.calledTimes)
+
+			for i := 0; i < test.calledTimes; i++ {
+				mockIndex.Anon(test.name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Closes #459.

**Description**

Introduce a new construct `Continue` on the controller. It will be almost like `ctrl.Finish` with the following differences.

1. It can be called multiple times from the user code.
2. It will implicitly reset the calls at the end.

Above will ensure that when the user code calls `ctrl.Continue()` all the expectations are checked for and calls are also reset. Now, user code can reuse the same controller to define new expectations. Older expectations are no longer in the picture. This way we can be sure that unmet expectations of any tests don't have side-effects on other tests

**Submitter Checklist**

- [x] Includes tests

**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Tests added.
