### PR TITLE
MOCK-429: add support for assignable types to Eq matcher

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -102,7 +102,21 @@ type eqMatcher struct {
 }
 
 func (e eqMatcher) Matches(x interface{}) bool {
-	return reflect.DeepEqual(e.x, x)
+	// In case, some value is nil
+	if e.x == nil || x == nil {
+		return reflect.DeepEqual(e.x, x)
+	}
+
+	// Check if types assignable and convert them to common type
+	x1Val := reflect.ValueOf(e.x)
+	x2Val := reflect.ValueOf(x)
+
+	if x1Val.Type().AssignableTo(x2Val.Type()) {
+		x1ValConverted := x1Val.Convert(x2Val.Type())
+		return reflect.DeepEqual(x1ValConverted.Interface(), x2Val.Interface())
+	}
+
+	return false
 }
 
 func (e eqMatcher) String() string {

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/golang/mock/gomock/internal/mock_gomock"
 )
 
+type A []string
+
 func TestMatchers(t *testing.T) {
 	type e interface{}
 	tests := []struct {
@@ -43,6 +45,10 @@ func TestMatchers(t *testing.T) {
 		{"test Len", gomock.Len(2),
 			[]e{[]int{1, 2}, "ab", map[string]int{"a": 0, "b": 1}, [2]string{"a", "b"}},
 			[]e{[]int{1}, "a", 42, 42.0, false, [1]string{"a"}},
+		},
+		{"test assignable types", gomock.Eq(A{"a", "b"}),
+			[]e{[]string{"a", "b"}, A{"a", "b"}},
+			[]e{[]string{"a"}, A{"b"}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Solution to https://github.com/golang/mock/issues/429. Adds support for assignable types to `Eq` matcher.