### PR TITLE
fix Test_createPackageMap for 1.15

### DIFF
--- a/mockgen/parse_test.go
+++ b/mockgen/parse_test.go
@@ -70,7 +70,7 @@ func TestImportsOfFile(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	imports, _ := importsOfFile(file)
+	imports, _, _ := importsOfFile(file)
 	checkGreeterImports(t, imports)
 }
 


### PR DESCRIPTION
In Go 1.15 `go list` will return an error if any of the pacakges
passed to it are not valid. This differs from pervious behavior
where all of the successful results would be returned. In practice
this should not be an issue as code should contain resolvable
import paths, but this made the test fail.

Also, in case `go list` does return an error, lets return that to
the user.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number>. _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests

**Reviewer Notes**

- [ ] The code flow looks good.
- [ ] Tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- Improved API for custom matchers
```
