### PR TITLE
implement error equality

### DIFF
--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -109,6 +109,25 @@ func (e eqMatcher) String() string {
 	return fmt.Sprintf("is equal to %v", e.x)
 }
 
+type eqErrorMatcher struct {
+	err error
+}
+
+func (e eqErrorMatcher) Matches(x interface{}) bool {
+	err, ok := x.(error)
+	if !ok {
+		return false
+	}
+	if err.Error() != e.err.Error() {
+		return false
+	}
+	return true
+}
+
+func (e eqErrorMatcher) String() string {
+	return fmt.Sprintf("is equal to %s", e.err.Error())
+}
+
 type nilMatcher struct{}
 
 func (nilMatcher) Matches(x interface{}) bool {
@@ -209,6 +228,19 @@ func Any() Matcher { return anyMatcher{} }
 //   Eq(5).Matches(5) // returns true
 //   Eq(5).Matches(4) // returns false
 func Eq(x interface{}) Matcher { return eqMatcher{x} }
+
+// EqError returns a matcher that matches on equality message error (only one an error interface type)
+//
+// Example usage:
+//   var err1 error = errors.New("content error 1")
+//   var err2 error = errors.New("content error 2")
+//   var errCustom1 error = CustomError.Error{msg: "content error 1"}
+//   var errCustom2 error = CustomError.Error{msg: "content error 2"}
+//   EqError(err1).Matches(err1) // true
+//   EqError(err1).Matches(err2) // false
+//   EqError(err1).Matches(errCustom1) // true
+//   EqError(err1).Matches(errCustom2) // false
+func EqError(err error) Matcher { return eqErrorMatcher{err} }
 
 // Len returns a matcher that matches on length. This matcher returns false if
 // is compared to a type that is not an array, chan, map, slice, or string.

--- a/gomock/matchers_test.go
+++ b/gomock/matchers_test.go
@@ -26,7 +26,21 @@ import (
 	"github.com/golang/mock/gomock/internal/mock_gomock"
 )
 
+// CustomError to provide a specific use case in the test
+type CustomError struct {
+	msg string
+}
+
+// Error method to implement error interface
+func (c CustomError) Error() string {
+	return c.msg
+}
+
 func TestMatchers(t *testing.T) {
+	err1 := errors.New("content error 1")
+	err2 := errors.New("content error 2")
+	var errCustom1 error = &CustomError{msg: "content error 1"}
+	var errCustom2 error = &CustomError{msg: "content error 2"}
 	type e interface{}
 	tests := []struct {
 		name    string
@@ -34,7 +48,7 @@ func TestMatchers(t *testing.T) {
 		yes, no []e
 	}{
 		{"test Any", gomock.Any(), []e{3, nil, "foo"}, nil},
-		{"test All", gomock.Eq(4), []e{4}, []e{3, "blah", nil, int64(4)}},
+		{"test Eq", gomock.Eq(4), []e{4}, []e{3, "blah", nil, int64(4)}},
 		{"test Nil", gomock.Nil(),
 			[]e{nil, (error)(nil), (chan bool)(nil), (*int)(nil)},
 			[]e{"", 0, make(chan bool), errors.New("err"), new(int)}},
@@ -44,6 +58,7 @@ func TestMatchers(t *testing.T) {
 			[]e{[]int{1, 2}, "ab", map[string]int{"a": 0, "b": 1}, [2]string{"a", "b"}},
 			[]e{[]int{1}, "a", 42, 42.0, false, [1]string{"a"}},
 		},
+		{"test EqError", gomock.EqError(errors.New("content error 1")), []e{err1, errCustom1}, []e{err2, errCustom2, 42, 42.0, "42"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes ##487

**Description**

```
// EqError returns a matcher that matches on equality message error (only one an error interface type)
//
// Example usage:
//   var err1 error = errors.New("content error 1")
//   var err2 error = errors.New("content error 2")
//   var errCustom1 error = CustomError.Error{msg: "content error 1"}
//   var errCustom2 error = CustomError.Error{msg: "content error 2"}
//   EqError(err1).Matches(err1) // true
//   EqError(err1).Matches(err2) // false
//   EqError(err1).Matches(errCustom1) // true
//   EqError(err1).Matches(errCustom2) // false
```

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ x] Includes tests

**Reviewer Notes**

- [ x] The code flow looks good.
- [ x] Tests added.

```
No change, just add a Matcher and it was documented and tested
```
