### PR TITLE
fix Test_createPackageMap for 1.15

### DIFF
--- a/mockgen/internal/tests/mock_in_test_package/mock_test.go
+++ b/mockgen/internal/tests/mock_in_test_package/mock_test.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mock_in_test_package "github.com/golang/mock/mockgen/internal/tests/mock_in_test_package"
+	users "github.com/golang/mock/mockgen/internal/tests/mock_in_test_package"
 )
 
 // MockFinder is a mock of Finder interface.
@@ -35,7 +35,7 @@ func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 }
 
 // Add mocks base method.
-func (m *MockFinder) Add(u mock_in_test_package.User) {
+func (m *MockFinder) Add(u users.User) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Add", u)
 }
@@ -47,10 +47,10 @@ func (mr *MockFinderMockRecorder) Add(u interface{}) *gomock.Call {
 }
 
 // FindUser mocks base method.
-func (m *MockFinder) FindUser(name string) mock_in_test_package.User {
+func (m *MockFinder) FindUser(name string) users.User {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindUser", name)
-	ret0, _ := ret[0].(mock_in_test_package.User)
+	ret0, _ := ret[0].(users.User)
 	return ret0
 }
 

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -637,25 +637,27 @@ func (g *generator) Output() []byte {
 // createPackageMap returns a map of import path to package name
 // for specified importPaths.
 func createPackageMap(importPaths []string) map[string]string {
-	var pkg struct {
-		Name       string
-		ImportPath string
-	}
 	pkgMap := make(map[string]string)
 	b := bytes.NewBuffer(nil)
-	args := []string{"list", "-json"}
+	args := []string{"list", "-e", "-json"}
 	args = append(args, importPaths...)
 	cmd := exec.Command("go", args...)
 	cmd.Stdout = b
 	cmd.Run()
 	dec := json.NewDecoder(b)
 	for dec.More() {
+		var pkg struct {
+			Name       string
+			ImportPath string
+		}
 		err := dec.Decode(&pkg)
 		if err != nil {
 			log.Printf("failed to decode 'go list' output: %v", err)
 			continue
 		}
-		pkgMap[pkg.ImportPath] = pkg.Name
+		if pkg.Name != "" {
+			pkgMap[pkg.ImportPath] = pkg.Name
+		}
 	}
 	return pkgMap
 }


### PR DESCRIPTION
In Go 1.15 go list will return an error if any of the packages
passed to it are not valid. This differs from pervious behavior
where all of the successful results would be returned. In practice
this should not be an issue as code should contain resolvable
import paths, but this made the test fail.