### PR TITLE
fix a little bug of example code

### DIFF
--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -26,7 +26,7 @@
 //           defer mockCtrl.Finish()
 //
 //           mockObj := something.NewMockMyInterface(mockCtrl)
-//           mockObj.EXPECT().SomeMethod(4, "blah")
+//           mockObj.EXPECT().SomeMethod(int64(4), "blah")
 //           // pass mockObj to a real object and play with it.
 //         }
 //


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

when I tries to make a test of GoMock referring to the example listed in the doc, I always get
----------------
--- FAIL: TestMyThing (0.00s)
    c:\Users\bxshc\Documents\projects\design-pattern\48\busi\busi_test.go:22: Unexpected call to *mock_busi.MockMyInterface.SomeMethod1([4]) at c:/Users/bxshc/Documents/projects/design-pattern/48/busi/mock_busi/mock_busi.go:50 because: 
        expected call at c:/Users/bxshc/Documents/projects/design-pattern/48/busi/busi_test.go:18 doesn't match the argument at index 0.
        Got: 4
        Want: is equal to 4
-----------------
so I think there maybe something wrong with the type, then I debug it and found that it should specify the exact type of 4 as int64,  a pure 4 will result in a type of int. 

the change is very simple, just as 
-----------
-           mockObj.EXPECT().SomeMethod(4, "blah")
+          mockObj.EXPECT().SomeMethod(int64(4), "blah")
-----------
so that's all, may you should change the example or make a more intelligent infer from the original interface information when generate the mock code.

thanks！