### PR TITLE
fix Test_createPackageMap for 1.15

### DIFF
--- a/mockgen/mockgen_test.go
+++ b/mockgen/mockgen_test.go
@@ -344,8 +344,6 @@ func Test_createPackageMap(t *testing.T) {
 	}{
 		{"golang package", "context", "context", true},
 		{"third party", "golang.org/x/tools/present", "present", true},
-		//{"modules", "rsc.io/quote/v3", "quote", true},
-		{"fail", "this/should/not/work", "", false},
 	}
 	var importPaths []string
 	for _, t := range tests {


### PR DESCRIPTION
In Go 1.15 go list will return an error if any of the packages
passed to it are not valid. This differs from pervious behavior
where all of the successful results would be returned. In practice
this should not be an issue as code should contain resolvable
import paths, but this made the test fail.