### PR TITLE
allow for overriding source package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Alternatively, there is an online reference for the package hosted on GoPkgDoc
 
 Source mode generates mock interfaces from a source file.
 It is enabled by using the -source flag. Other flags that
-may be useful in this mode are -imports and -aux_files.
+may be useful in this mode are -imports, -aux_files and -source_package.
 
 Example:
 
@@ -89,6 +89,10 @@ It supports the following flags:
   specified as a comma-separated list of elements of the form
   `foo=bar/baz.go`, where `bar/baz.go` is the source file and `foo` is the
   package name of that file used by the -source file.
+
+- `-source_package`: The full package import path for the source code.
+  This is used if the generated code must import from the source code.
+  If omitted, it will be inferred from Go modules and GOPATH.
 
 - `-build_flags`: (reflect mode only) Flags passed verbatim to `go build`.
 

--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -37,8 +37,9 @@ import (
 )
 
 var (
-	imports  = flag.String("imports", "", "(source mode) Comma-separated name=path pairs of explicit imports to use.")
-	auxFiles = flag.String("aux_files", "", "(source mode) Comma-separated pkg=path pairs of auxiliary Go source files.")
+	imports       = flag.String("imports", "", "(source mode) Comma-separated name=path pairs of explicit imports to use.")
+	auxFiles      = flag.String("aux_files", "", "(source mode) Comma-separated pkg=path pairs of auxiliary Go source files.")
+	sourcePackage = flag.String("source_package", "", "The full package import path for the source code. This is used if the generated code must import from the source code. If omitted, it will be inferred from Go modules and GOPATH.")
 )
 
 // TODO: simplify error reporting
@@ -50,9 +51,12 @@ func sourceMode(source string) (*model.Package, error) {
 		return nil, fmt.Errorf("failed getting source directory: %v", err)
 	}
 
-	packageImport, err := parsePackageImport(srcDir)
-	if err != nil {
-		return nil, err
+	packageImport := *sourcePackage
+	if packageImport == "" {
+		packageImport, err = parsePackageImport(srcDir)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	fs := token.NewFileSet()


### PR DESCRIPTION
Greetings!

We call `mockgen` from bazel, which lives in a hermetic environment and doesn't have access to go modules or GOPATH. However, we shouldn't really need to magically find the name of the go package.

This PR adds a flag to override the source package - so that if the mock file needs to import from the original file, it'll use the provided package.

I looked at writing tests. I didn't put this in `parsePackageImport` because that function is called in multiple places, including to determine the destination path. We don't want to override the destination path. I thought about creating a new function, `getPackageName` or something, but it didn't seem worthwhile.