### PR TITLE
fix error message in parse.go

### DIFF
--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -628,4 +628,4 @@ func packageNameOfDir(srcDir string) (string, error) {
 	return packageImport, nil
 }
 
-var errOutsideGoPath = errors.New("Source directory is outside GOPATH")
+var errOutsideGoPath = errors.New("source directory is outside GOPATH")


### PR DESCRIPTION
Hi team.

fixed error message becasue error strings should not be capitalized.

https://github.com/golang/go/wiki/CodeReviewComments#error-strings

> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. That is, use fmt.Errorf("something bad") not fmt.Errorf("Something bad"), so that log.Printf("Reading %s: %v", filename, err) formats without a spurious capital letter mid-message. This does not apply to logging, which is implicitly line-oriented and not combined inside other messages.

