### PR TITLE
Best effort guesses for output package path

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -136,12 +136,15 @@ func main() {
 	outputPackagePath := *selfPackage
 	if outputPackagePath == "" && *destination != "" {
 		dstPath, err := filepath.Abs(filepath.Dir(*destination))
-		if err != nil {
-			log.Fatalf("Unable to determine destination file path: %v", err)
-		}
-		outputPackagePath, err = parsePackageImport(dstPath)
-		if err != nil {
-			log.Fatalf("Unable to determine destination file path: %v", err)
+		if err == nil {
+			pkgPath, err := parsePackageImport(dstPath)
+			if err == nil {
+				outputPackagePath = pkgPath
+			} else {
+				log.Println("Unable to determine destination package path:", err)
+			}
+		} else {
+			log.Println("Unable to determine destination file path:", err)
 		}
 	}
 

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -141,7 +141,7 @@ func main() {
 			if err == nil {
 				outputPackagePath = pkgPath
 			} else {
-				log.Println("Unable to determine destination package path:", err)
+				log.Println("Unable to infer -self_package from destination file path:", err)
 			}
 		} else {
 			log.Println("Unable to determine destination file path:", err)


### PR DESCRIPTION
I know we need output package path to avoid self-importing. However, this only happens when the mock is output into an already existing package, in which case the caller is responsible for passing `-self_package`. Without `-self_package`, guessing output package path should be on best effort basis. There is no requirement for `destination` to be in a Go module or `GOPATH` (in fact, it's hard, if possible at all, to do so in Bazel). So `parsePackageImport(dstPath)` often fails. Such failure should not fail the main program. We should instead be optimistic and leave output package package empty, assuming no self importing would happen.