### PR TITLE
add type information to error messages

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -437,7 +437,7 @@ func (c *Call) addAction(action func([]interface{}) []interface{}) {
 }
 
 func formatGottenArg(m Matcher, arg interface{}) string {
-	got := fmt.Sprintf("%v", arg)
+	got := fmt.Sprintf("%v (%T)", arg, arg)
 	if gs, ok := m.(GotFormatter); ok {
 		got = gs.Got(arg)
 	}

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -288,13 +288,13 @@ func TestUnexpectedArgValue_FirstArg(t *testing.T) {
 		// the method argument (of TestStruct type) has 1 unexpected value (for the Message field)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "no message"}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {123 no message}\nWant: is equal to {123 hello}")
+		"Got: {123 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello} (gomock_test.TestStruct)")
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 2 unexpected values (for both fields)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message"}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {11 no message}\nWant: is equal to {123 hello}")
+		"Got: {11 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello} (gomock_test.TestStruct)")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.
@@ -313,7 +313,7 @@ func TestUnexpectedArgValue_SecondArg(t *testing.T) {
 	reporter.assertFatal(func() {
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "hello"}, 3)
 	}, "Unexpected call to", "doesn't match the argument at index 1",
-		"Got: 3\nWant: is equal to 15")
+		"Got: 3 (int)\nWant: is equal to 15 (int)")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.
@@ -340,7 +340,7 @@ func TestUnexpectedArgValue_WantFormatter(t *testing.T) {
 	reporter.assertFatal(func() {
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "hello"}, 3)
 	}, "Unexpected call to", "doesn't match the argument at index 1",
-		"Got: 3\nWant: is equal to fifteen")
+		"Got: 3 (int)\nWant: is equal to fifteen")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.
@@ -711,7 +711,7 @@ func TestVariadicNoMatch(t *testing.T) {
 	rep.assertFatal(func() {
 		ctrl.Call(s, "VariadicMethod", 1)
 	}, "expected call at", "doesn't match the argument at index 0",
-		"Got: 1\nWant: is equal to 0")
+		"Got: 1 (int)\nWant: is equal to 0 (int)")
 	ctrl.Call(s, "VariadicMethod", 0)
 	ctrl.Finish()
 }

--- a/gomock/matchers.go
+++ b/gomock/matchers.go
@@ -120,7 +120,7 @@ func (e eqMatcher) Matches(x interface{}) bool {
 }
 
 func (e eqMatcher) String() string {
-	return fmt.Sprintf("is equal to %v", e.x)
+	return fmt.Sprintf("is equal to %v (%T)", e.x, e.x)
 }
 
 type nilMatcher struct{}


### PR DESCRIPTION
- Adds type information to the default got formatter.
- Adds type to default want formatter. This happens to be
  gomock.Eq. Adding more information for debugging seems like a
  good idea in this case as well.

Fixes: #190