### PR TITLE
fix ill-formatted message with fmt-verbs like %s

### DIFF
--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -16,6 +16,7 @@ package gomock
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 )
 
@@ -95,7 +96,7 @@ func (cs callSet) FindMatch(receiver interface{}, method string, args []interfac
 		_, _ = fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q for that receiver", method)
 	}
 
-	return nil, fmt.Errorf(callsErrors.String())
+	return nil, errors.New(callsErrors.String())
 }
 
 // Failures returns the calls that are not satisfied.

--- a/gomock/controller_test.go
+++ b/gomock/controller_test.go
@@ -281,20 +281,20 @@ func TestUnexpectedArgValue_FirstArg(t *testing.T) {
 	defer reporter.recoverUnexpectedFatal()
 	subject := new(Subject)
 
-	expectedArg0 := TestStruct{Number: 123, Message: "hello"}
+	expectedArg0 := TestStruct{Number: 123, Message: "hello %s"}
 	ctrl.RecordCall(subject, "ActOnTestStructMethod", expectedArg0, 15)
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 1 unexpected value (for the Message field)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 123, Message: "no message"}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {123 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello} (gomock_test.TestStruct)")
+		"Got: {123 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello %s} (gomock_test.TestStruct)")
 
 	reporter.assertFatal(func() {
 		// the method argument (of TestStruct type) has 2 unexpected values (for both fields)
 		ctrl.Call(subject, "ActOnTestStructMethod", TestStruct{Number: 11, Message: "no message"}, 15)
 	}, "Unexpected call to", "doesn't match the argument at index 0",
-		"Got: {11 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello} (gomock_test.TestStruct)")
+		"Got: {11 no message} (gomock_test.TestStruct)\nWant: is equal to {123 hello %s} (gomock_test.TestStruct)")
 
 	reporter.assertFatal(func() {
 		// The expected call wasn't made.


### PR DESCRIPTION
If [fmt](https://pkg.go.dev/fmt)-verb strings such as `%s` is included in the error message, the output becomes `%!s(MISSING)` unintendedly.

This pull request fixes this problem.