### PR TITLE
Move argument requirements for Do and DoAndReturn out of example code and into function commentary

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -108,6 +108,7 @@ func (c *Call) MaxTimes(n int) *Call {
 // DoAndReturn declares the action to run when the call is matched.
 // The return values from this function are returned by the mocked function.
 // It takes an interface{} argument to support n-arity functions.
+// The anonymous function must have the same number of input and output arguments as the mocked method.
 func (c *Call) DoAndReturn(f interface{}) *Call {
 	// TODO: Check arity and types here, rather than dying badly elsewhere.
 	v := reflect.ValueOf(f)
@@ -143,6 +144,7 @@ func (c *Call) DoAndReturn(f interface{}) *Call {
 // return values are ignored to retain backward compatibility. To use the
 // return values call DoAndReturn.
 // It takes an interface{} argument to support n-arity functions.
+// The anonymous function must have the same number of input arguments as the mocked method.
 func (c *Call) Do(f interface{}) *Call {
 	// TODO: Check arity and types here, rather than dying badly elsewhere.
 	v := reflect.ValueOf(f)

--- a/gomock/example_test.go
+++ b/gomock/example_test.go
@@ -20,7 +20,6 @@ func ExampleCall_DoAndReturn_latency() {
 	mockIndex := NewMockFoo(ctrl)
 
 	mockIndex.EXPECT().Bar(gomock.Any()).DoAndReturn(
-		// signature of anonymous function must have the same number of input and output arguments as the mocked method.
 		func(arg string) string {
 			time.Sleep(1 * time.Millisecond)
 			return "I'm sleepy"
@@ -39,7 +38,6 @@ func ExampleCall_DoAndReturn_captureArguments() {
 	var s string
 
 	mockIndex.EXPECT().Bar(gomock.AssignableToTypeOf(s)).DoAndReturn(
-		// signature of anonymous function must have the same number of input and output arguments as the mocked method.
 		func(arg string) interface{} {
 			s = arg
 			return "I'm sleepy"


### PR DESCRIPTION
Regardless of the result of #558, this is not a new requirement (I believe), and the location of it in the example code was easy to miss.

The `Do` version excludes a reference to the output argument count, as the returns are ignored.