### PR TITLE
Add argMatcher for creating new calls

### DIFF
--- a/gomock/callset_test.go
+++ b/gomock/callset_test.go
@@ -30,7 +30,7 @@ func TestCallSetAdd(t *testing.T) {
 
 	numCalls := 10
 	for i := 0; i < numCalls; i++ {
-		cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func)))
+		cs.Add(newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func), nil))
 	}
 
 	call, err := cs.FindMatch(receiver, method, []interface{}{})
@@ -82,7 +82,7 @@ func TestCallSetFindMatch(t *testing.T) {
 		method := "TestMethod"
 		args := []interface{}{}
 
-		c1 := newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func))
+		c1 := newCall(t, receiver, method, reflect.TypeOf(receiverType{}.Func), nil)
 		cs.exhausted = map[callSetKey][]*Call{
 			{receiver: receiver, fname: method}: {c1},
 		}

--- a/gomock/controller.go
+++ b/gomock/controller.go
@@ -117,6 +117,7 @@ type Controller struct {
 	mu            sync.Mutex
 	expectedCalls *callSet
 	finished      bool
+	ArgMatcher    ArgMatcher
 }
 
 // NewController returns a new Controller. It is the preferred way to create a
@@ -203,7 +204,7 @@ func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...
 func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
 	ctrl.T.Helper()
 
-	call := newCall(ctrl.T, receiver, method, methodType, args...)
+	call := newCall(ctrl.T, receiver, method, methodType, ctrl.ArgMatcher, args...)
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()

--- a/gomock/mock_test.go
+++ b/gomock/mock_test.go
@@ -33,16 +33,16 @@ func (m *MockFoo) EXPECT() *MockFooMockRecorder {
 	return m.recorder
 }
 
-// Bar mocks base method.
+// Dummy mocks base method.
 func (m *MockFoo) Bar(arg0 string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bar", arg0)
+	ret := m.ctrl.Call(m, "Dummy", arg0)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
-// Bar indicates an expected call of Bar.
+// Dummy indicates an expected call of Dummy.
 func (mr *MockFooMockRecorder) Bar(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bar", reflect.TypeOf((*MockFoo)(nil).Bar), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Dummy", reflect.TypeOf((*MockFoo)(nil).Bar), arg0)
 }


### PR DESCRIPTION
Suggested change provides opportunity to override default matcher in which arguments are wrapped when creating a new call.

Currently "gomock.Eq" is hardcoded for these purposes, and if you need to change it and you already have hundreds of tests, it seems merely possible.