### PR TITLE
Updated README with correct information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ GO111MODULE=on go get github.com/golang/mock/mockgen@v1.6.0
 ### Go 1.16+
 
 ```bash
-go install github.com/golang/mock/mockgen@v1.6.0
+go get github.com/golang/mock/mockgen@v1.6.0
 ```
 
 If you use `mockgen` in your CI pipeline, it may be more appropriate to fixate


### PR DESCRIPTION
`go install` is not working with `path@version` and can only be used with `go get` syntax. Following is the error you get when you use `go install github.com/golang/mock/mockgen@v1.6.0`

> package github.com/golang/mock/mockgen@latest: can only use path@version syntax with 'go get'