### PR TITLE
AST duplication compare only by paths, not by alias. Fix it

### DIFF
--- a/mockgen/parse.go
+++ b/mockgen/parse.go
@@ -232,7 +232,7 @@ func (p *fileParser) parsePackage(path string) (*fileParser, error) {
 	}
 
 	for _, pkg := range pkgs {
-		file := ast.MergePackageFiles(pkg, ast.FilterFuncDuplicates|ast.FilterUnassociatedComments|ast.FilterImportDuplicates)
+		file := ast.MergePackageFiles(pkg, ast.FilterFuncDuplicates|ast.FilterUnassociatedComments)
 		if _, ok := newP.importedInterfaces[path]; !ok {
 			newP.importedInterfaces[path] = make(map[string]*ast.InterfaceType)
 		}
@@ -561,10 +561,7 @@ func importsOfFile(file *ast.File) (normalImports map[string]importedPackage, do
 						duplicates: append([]string{importPath}, p.duplicates...),
 					}
 				case importedPkg:
-					normalImports[pkgName] = duplicateImport{
-						name:       pkgName,
-						duplicates: []string{p.path, importPath},
-					}
+					continue
 				}
 			} else {
 				normalImports[pkgName] = importedPkg{path: importPath}


### PR DESCRIPTION
HI.
AST removing duplicates works not correct for local aliasing.
If you have several imports ta package with different local names - it will bring some pain like "unknown package" because ast  remove all packages with another local naming. From the library source:
go/ast/filter.go:458
```if mode&FilterImportDuplicates != 0 {
		seen := make(map[string]bool)
		for _, filename := range filenames {
			f := pkg.Files[filename]
			for _, imp := range f.Imports {
				if path := imp.Path.Value; !seen[path] {
					// TODO: consider handling cases where:
					// - 2 imports exist with the same import path but
					//   have different local names (one should probably
					//   keep both of them)
					// - 2 imports exist but only one has a comment
					// - 2 imports exist and they both have (possibly
					//   different) comments
					imports = append(imports, imp)
					seen[path] = true
				}
			}
		}
```

So this PR tries to fix this by handling duplicates by skipping them.
