### PR TITLE
fix: avoid pkg name <> import pkg name conflicts

### DIFF
--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -307,7 +307,7 @@ func (g *generator) Generate(pkg *model.Package, outputPkgName string, outputPac
 
 	g.packageMap = make(map[string]string, len(im))
 	localNames := make(map[string]bool, len(im))
-	// Avoid package name conflicts with an imported package names.
+	// Avoid package name conflicts with imported package names.
 	localNames[pkg.Name] = true
 	for _, pth := range sortedPaths {
 		base, ok := packagesName[pth]

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -308,7 +308,7 @@ func (g *generator) Generate(pkg *model.Package, outputPkgName string, outputPac
 	g.packageMap = make(map[string]string, len(im))
 	localNames := make(map[string]bool, len(im))
 	// Avoid package name conflicts with imported package names.
-	localNames[pkg.Name] = true
+	localNames[outputPkgName] = true
 	for _, pth := range sortedPaths {
 		base, ok := packagesName[pth]
 		if !ok {

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -307,6 +307,8 @@ func (g *generator) Generate(pkg *model.Package, outputPkgName string, outputPac
 
 	g.packageMap = make(map[string]string, len(im))
 	localNames := make(map[string]bool, len(im))
+	// Avoid package name conflicts with an imported package names.
+	localNames[pkg.Name] = true
 	for _, pth := range sortedPaths {
 		base, ok := packagesName[pth]
 		if !ok {


### PR DESCRIPTION
Avoid package name conflicts with an imported package name. 