### PR TITLE
Skip rewriting output files if unchanged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ mockgen/mockgen
 # Editors
 .vscode
 .idea
+
+# vendor directory used for IDEs
+/vendor

--- a/mockgen/internal/tests/mock_in_test_package/mock_test.go
+++ b/mockgen/internal/tests/mock_in_test_package/mock_test.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	mock_in_test_package "github.com/golang/mock/mockgen/internal/tests/mock_in_test_package"
+	users "github.com/golang/mock/mockgen/internal/tests/mock_in_test_package"
 )
 
 // MockFinder is a mock of Finder interface.
@@ -35,7 +35,7 @@ func (m *MockFinder) EXPECT() *MockFinderMockRecorder {
 }
 
 // Add mocks base method.
-func (m *MockFinder) Add(u mock_in_test_package.User) {
+func (m *MockFinder) Add(u users.User) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Add", u)
 }
@@ -47,10 +47,10 @@ func (mr *MockFinderMockRecorder) Add(u interface{}) *gomock.Call {
 }
 
 // FindUser mocks base method.
-func (m *MockFinder) FindUser(name string) mock_in_test_package.User {
+func (m *MockFinder) FindUser(name string) users.User {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindUser", name)
-	ret0, _ := ret[0].(mock_in_test_package.User)
+	ret0, _ := ret[0].(users.User)
 	return ret0
 }
 

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -165,7 +165,7 @@ func main() {
 		if err := os.MkdirAll(filepath.Dir(*destination), os.ModePerm); err != nil {
 			log.Fatalf("Unable to create directory: %v", err)
 		}
-		existing, err := os.ReadFile(*destination)
+		existing, err := ioutil.ReadFile(*destination)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Fatalf("Failed reading pre-exiting destination file: %v", err)
 		}

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -170,7 +170,6 @@ func main() {
 			log.Fatalf("Failed reading pre-exiting destination file: %v", err)
 		}
 		if len(existing) == len(output) && bytes.Compare(existing, output) == 0 {
-			log.Println("Pre-existing file is already up to date.")
 			return
 		}
 		f, err := os.Create(*destination)


### PR DESCRIPTION
When running mockgen with the output option this checks if the existing file content already exists and skips writing if there is nothing to change.

This will help reduce i/o when changing lots of files, but also reduce the re-indexing triggering in IDEs.

Solves #604