### PR TITLE
Add -package_format to customize the generated package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ It supports the following flags:
   don't set this, the code is printed to standard output.
 
 - `-package`: The package to use for the resulting mock class
-  source code. If you don't set this, the package name is `mock_` concatenated
-  with the package of the input file.
+  source code. If you don't set this, the name is formatted with -package_format.
+
+- `-package_format`: The package name format when -package is not specified.
+  If you don't set this, `mock_%s` will be used.
 
 - `-imports`: A list of explicit imports that should be used in the resulting
   source code, specified as a comma-separated list of elements of the form

--- a/mockgen/mockgen.go
+++ b/mockgen/mockgen.go
@@ -53,13 +53,14 @@ var (
 )
 
 var (
-	source          = flag.String("source", "", "(source mode) Input Go source file; enables source mode.")
-	destination     = flag.String("destination", "", "Output file; defaults to stdout.")
-	mockNames       = flag.String("mock_names", "", "Comma-separated interfaceName=mockName pairs of explicit mock names to use. Mock names default to 'Mock'+ interfaceName suffix.")
-	packageOut      = flag.String("package", "", "Package of the generated code; defaults to the package of the input with a 'mock_' prefix.")
-	selfPackage     = flag.String("self_package", "", "The full package import path for the generated code. The purpose of this flag is to prevent import cycles in the generated code by trying to include its own package. This can happen if the mock's package is set to one of its inputs (usually the main one) and the output is stdio so mockgen cannot detect the final output package. Setting this flag will then tell mockgen which import to exclude.")
-	writePkgComment = flag.Bool("write_package_comment", true, "Writes package documentation comment (godoc) if true.")
-	copyrightFile   = flag.String("copyright_file", "", "Copyright file used to add copyright header")
+	source           = flag.String("source", "", "(source mode) Input Go source file; enables source mode.")
+	destination      = flag.String("destination", "", "Output file; defaults to stdout.")
+	mockNames        = flag.String("mock_names", "", "Comma-separated interfaceName=mockName pairs of explicit mock names to use. Mock names default to 'Mock'+ interfaceName suffix.")
+	packageOut       = flag.String("package", "", "Package of the generated code; defaults to the name formatted with -package_format.")
+	packageOutFormat = flag.String("package_format", "mock_%s", "The package name format when -package is not specified. Only one %s should be included.")
+	selfPackage      = flag.String("self_package", "", "The full package import path for the generated code. The purpose of this flag is to prevent import cycles in the generated code by trying to include its own package. This can happen if the mock's package is set to one of its inputs (usually the main one) and the output is stdio so mockgen cannot detect the final output package. Setting this flag will then tell mockgen which import to exclude.")
+	writePkgComment  = flag.Bool("write_package_comment", true, "Writes package documentation comment (godoc) if true.")
+	copyrightFile    = flag.String("copyright_file", "", "Copyright file used to add copyright header")
 
 	debugParser = flag.Bool("debug_parser", false, "Print out parser results only.")
 	showVersion = flag.Bool("version", false, "Print version.")
@@ -124,7 +125,7 @@ func main() {
 	if outputPackageName == "" {
 		// pkg.Name in reflect mode is the base name of the import path,
 		// which might have characters that are illegal to have in package names.
-		outputPackageName = "mock_" + sanitize(pkg.Name)
+		outputPackageName = fmt.Sprintf(*packageOutFormat, sanitize(pkg.Name))
 	}
 
 	// outputPackagePath represents the fully qualified name of the package of


### PR DESCRIPTION
Previously `-package` must be explicitly defined or it will default
to `mock_${name}`. To generate a mock file that sits next to the
package files, eg. as part of the test, one must extract the package
name first. Which is not scripting-friendly.

After this change, we can use `-package_format` to customize the
generated package name. So that a script can run mockgen without
knowing the package name first.

Fixes #631 