### PR TITLE
Add call.Optional()

### DIFF
--- a/gomock/call.go
+++ b/gomock/call.go
@@ -38,6 +38,8 @@ type Call struct {
 
 	numCalls int // actual number made
 
+	optional bool // if not called don't throw error
+
 	// actions are called when this Call is called. Each action gets the args and
 	// can set the return values by returning a non-nil slice. Actions run in the
 	// order they are created.
@@ -102,6 +104,12 @@ func (c *Call) MaxTimes(n int) *Call {
 	if c.minCalls == 1 {
 		c.minCalls = 0
 	}
+	return c
+}
+
+// Optional allows the expectation to not be called.
+func (c *Call) Optional() *Call {
+	c.optional = true
 	return c
 }
 

--- a/gomock/callset.go
+++ b/gomock/callset.go
@@ -104,7 +104,7 @@ func (cs callSet) Failures() []*Call {
 	failures := make([]*Call, 0, len(cs.expected))
 	for _, calls := range cs.expected {
 		for _, call := range calls {
-			if !call.satisfied() {
+			if !call.satisfied() && !call.optional {
 				failures = append(failures, call)
 			}
 		}


### PR DESCRIPTION
Issue described in #655 

# Changes 
- Add `optional` property to Call
- Add `Optional()` to `Call`

# Example Test 
```golang 
// Will not throw "aborting test due to missing call(s)"
func TestOptional(t *testing.T) {
	ctrl := gomock.NewController(t)
	defer ctrl.Finish()

	mockIndex := NewMockIndex(ctrl)

	mockIndex.EXPECT().Get(gomock.Any()).Optional()
}
```

Thanks for any time spent reviewing this PR ❤️ .

