### PR TITLE
gomock generics support enhancement

### DIFF
--- a/mockgen/internal/tests/generics/generics.go
+++ b/mockgen/internal/tests/generics/generics.go
@@ -38,3 +38,9 @@ type StructType struct{}
 type StructType2 struct{}
 
 type AliasType Baz[other.Three]
+
+type EmbeddingIface interface {
+	Bar[other.Three, error]
+	other.Otherer[StructType, other.Five]
+	LocalFunc() error
+}

--- a/mockgen/internal/tests/generics/other/other.go
+++ b/mockgen/internal/tests/generics/other/other.go
@@ -9,3 +9,9 @@ type Three struct{}
 type Four struct{}
 
 type Five interface{}
+
+type Otherer[T any, R any] interface {
+	DoT(T) error
+	DoR(R) error
+	MakeThem() (T, R, error)
+}

--- a/mockgen/model/model.go
+++ b/mockgen/model/model.go
@@ -61,6 +61,36 @@ type Interface struct {
 	TypeParams []*Parameter
 }
 
+// TypeParamIndexByName returns the index of the type parameter matching on name. If none matching, returns -1, nil.
+//
+// This is especially useful for generics where interface is something like this:
+//    Doer[T any, K any]{
+//        Start(T)
+//        Add(K) error
+//        Stop() []K
+//    }
+//
+// But it is used like this:
+//    type MyDoer = Doer[types.SomeType, otherPkg.SomeOtherThing]
+// or as an embedded interface:
+//    type MyDoer interface {
+//        Doer[types.SomeType, otherPkg.SomeOtherThing]
+//    }
+//
+// If parsing the Add method for an implementation of this interface,
+// we need to be able to swap out K for whatever the actual type is.
+// K will be at index 1 of the interface's TypeParams,
+// but it will also be at index 1 of the actual type params in either the
+// definition of the interface being mocked or the generic interface it embeds.
+func (intf *Interface) TypeParamIndexByName(name string) int {
+	for i, p := range intf.TypeParams {
+		if p.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
 // Print writes the interface name and its methods.
 func (intf *Interface) Print(w io.Writer) {
 	_, _ = fmt.Fprintf(w, "interface %s\n", intf.Name)
@@ -90,6 +120,22 @@ type Method struct {
 	Name     string
 	In, Out  []*Parameter
 	Variadic *Parameter // may be nil
+}
+
+func (m *Method) Clone() *Method {
+	mm := &Method{
+		Name:     m.Name,
+		In:       make([]*Parameter, 0),
+		Out:      make([]*Parameter, 0),
+		Variadic: m.Variadic.clone(),
+	}
+	for _, in := range m.In {
+		mm.In = append(mm.In, in.clone())
+	}
+	for _, out := range m.Out {
+		mm.Out = append(mm.Out, out.clone())
+	}
+	return mm
 }
 
 // Print writes the method name and its signature.
@@ -131,6 +177,16 @@ type Parameter struct {
 	Type Type
 }
 
+func (p *Parameter) clone() *Parameter {
+	if p == nil {
+		return nil
+	}
+	return &Parameter{
+		Name: p.Name,
+		Type: p.Type.clone(),
+	}
+}
+
 // Print writes a method parameter.
 func (p *Parameter) Print(w io.Writer) {
 	n := p.Name
@@ -144,6 +200,7 @@ func (p *Parameter) Print(w io.Writer) {
 type Type interface {
 	String(pm map[string]string, pkgOverride string) string
 	addImports(im map[string]bool)
+	clone() Type
 }
 
 func init() {
@@ -180,6 +237,13 @@ func (at *ArrayType) String(pm map[string]string, pkgOverride string) string {
 
 func (at *ArrayType) addImports(im map[string]bool) { at.Type.addImports(im) }
 
+func (at *ArrayType) clone() Type {
+	return &ArrayType{
+		Len:  at.Len,
+		Type: at.Type.clone(),
+	}
+}
+
 // ChanType is a channel type.
 type ChanType struct {
 	Dir  ChanDir // 0, 1 or 2
@@ -198,6 +262,13 @@ func (ct *ChanType) String(pm map[string]string, pkgOverride string) string {
 }
 
 func (ct *ChanType) addImports(im map[string]bool) { ct.Type.addImports(im) }
+
+func (ct *ChanType) clone() Type {
+	return &ChanType{
+		Dir:  ct.Dir,
+		Type: ct.Type.clone(),
+	}
+}
 
 // ChanDir is a channel direction.
 type ChanDir int
@@ -247,6 +318,21 @@ func (ft *FuncType) addImports(im map[string]bool) {
 	}
 }
 
+func (ft *FuncType) clone() Type {
+	ftt := &FuncType{
+		In:       make([]*Parameter, 0),
+		Out:      make([]*Parameter, 0),
+		Variadic: ft.Variadic.clone(),
+	}
+	for _, in := range ft.In {
+		ftt.In = append(ftt.In, in.clone())
+	}
+	for _, out := range ft.Out {
+		ftt.Out = append(ftt.Out, out.clone())
+	}
+	return ftt
+}
+
 // MapType is a map type.
 type MapType struct {
 	Key, Value Type
@@ -259,6 +345,13 @@ func (mt *MapType) String(pm map[string]string, pkgOverride string) string {
 func (mt *MapType) addImports(im map[string]bool) {
 	mt.Key.addImports(im)
 	mt.Value.addImports(im)
+}
+
+func (mt *MapType) clone() Type {
+	return &MapType{
+		Key:   mt.Key,
+		Value: mt.Value.clone(),
+	}
 }
 
 // NamedType is an exported type in a package.
@@ -287,6 +380,15 @@ func (nt *NamedType) addImports(im map[string]bool) {
 	nt.TypeParams.addImports(im)
 }
 
+func (nt *NamedType) clone() Type {
+	ntt := &NamedType{
+		Package:    nt.Package,
+		Type:       nt.Type,
+		TypeParams: nt.TypeParams.clone().(*TypeParametersType),
+	}
+	return ntt
+}
+
 // PointerType is a pointer to another type.
 type PointerType struct {
 	Type Type
@@ -297,11 +399,16 @@ func (pt *PointerType) String(pm map[string]string, pkgOverride string) string {
 }
 func (pt *PointerType) addImports(im map[string]bool) { pt.Type.addImports(im) }
 
+func (pt *PointerType) clone() Type {
+	return &PointerType{Type: pt.Type.clone()}
+}
+
 // PredeclaredType is a predeclared type such as "int".
 type PredeclaredType string
 
 func (pt PredeclaredType) String(map[string]string, string) string { return string(pt) }
 func (pt PredeclaredType) addImports(map[string]bool)              {}
+func (pt PredeclaredType) clone() Type                             { return PredeclaredType(pt) }
 
 // TypeParametersType contains type paramters for a NamedType.
 type TypeParametersType struct {
@@ -331,6 +438,17 @@ func (tp *TypeParametersType) addImports(im map[string]bool) {
 	for _, v := range tp.TypeParameters {
 		v.addImports(im)
 	}
+}
+
+func (tp *TypeParametersType) clone() Type {
+	if tp == nil {
+		return nil
+	}
+	tpt := &TypeParametersType{}
+	for _, t := range tp.TypeParameters {
+		tpt.TypeParameters = append(tpt.TypeParameters, t.clone())
+	}
+	return tpt
 }
 
 // The following code is intended to be called by the program generated by ../reflect.go.

--- a/mockgen/model/model.go
+++ b/mockgen/model/model.go
@@ -381,10 +381,16 @@ func (nt *NamedType) addImports(im map[string]bool) {
 }
 
 func (nt *NamedType) clone() Type {
+	if nt == nil {
+		return nil
+	}
+
 	ntt := &NamedType{
-		Package:    nt.Package,
-		Type:       nt.Type,
-		TypeParams: nt.TypeParams.clone().(*TypeParametersType),
+		Package: nt.Package,
+		Type:    nt.Type,
+	}
+	if nt.TypeParams != nil {
+		ntt.TypeParams = nt.TypeParams.clone().(*TypeParametersType)
 	}
 	return ntt
 }


### PR DESCRIPTION
# Related Issue(s)

The related issues can be found in the `1.7.0 Milestone` doc: https://github.com/golang/mock/milestone/5, specifically issues #643 and #649 

# Goals

- [x] handle embedded interfaces from src pkg
- [x] handle embedded interfaces from external pkg
- [x] handle generic input parameters on generated mock
- [x] handle generic output parameters on generate mock

# Hiccups/Hangups

## Navigation and Data Flow

There were some parts that I found challenging to navigate - especially this being my first dive into this codebase. Much respect to the work that's been done - not trying to criticize - but some helpful comments would make it a bit easier for contributors. I tried to add useful comments to what I've added in this PR without being overly verbose - tough to balance b/c some of this stuff is complex.

## Build/Test Processes

I didn't see instructions for linting or adding of tests, etc... so I just tried to do what the github workflow does, which is run `./ci/test.sh`.

I am unable to get that to run nor am I able to do `go generate ./...` to re-generate all of the mocks in the `gomock/internal/tests/...` dirs. I get the following errors (even on `main` branch):

```sh
 ~/git/bdg-gomock   main  ./ci/test.sh 
~/git/bdg-gomock ~/git/bdg-gomock
~/git/bdg-gomock
~/git/bdg-gomock/mockgen/internal/tests/generics ~/git/bdg-gomock
~/git/bdg-gomock
/var/folders/3v/d4pfdq752wj3y14x_136dvww0000gn/T/tmp.ZAh3Kj6D /var/folders/3v/d4pfdq752wj3y14x_136dvww0000gn/T/tmp.ZAh3Kj6D
2022/07/11 15:00:11 Loading input failed: input.go:13:5: failed parsing returns: input.go:13:9: bad array size: strconv.Atoi: parsing "": invalid syntax
mockgen/internal/tests/const_array_length/input.go:5: running "mockgen": exit status 1
2022/07/11 15:00:14 Loading input failed: bugreport.go:31:2: unknown embedded interface Foo
mockgen/internal/tests/import_embedded_interface/bugreport.go:17: running "mockgen": exit status 1
package command-line-arguments
        prog.go:14:2: use of internal package github.com/golang/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg not allowed

 ✘  ~/git/bdg-gomock   main  go generate ./...
2022/07/11 15:00:41 Loading input failed: input.go:13:5: failed parsing returns: input.go:13:9: bad array size: strconv.Atoi: parsing "": invalid syntax
mockgen/internal/tests/const_array_length/input.go:5: running "mockgen": exit status 1
2022/07/11 15:00:45 Loading input failed: bugreport.go:31:2: unknown embedded interface Foo
mockgen/internal/tests/import_embedded_interface/bugreport.go:17: running "mockgen": exit status 1
package command-line-arguments
        prog.go:14:2: use of internal package github.com/golang/mock/mockgen/internal/tests/internal_pkg/subdir/internal/pkg not allowed
```

Are we supposed to run `go generate ./...` from the root (or anywhere else)?

# Proving Grounds

Though I had some hangups trying to prove this out, I was able to prove out reasonably enough that this works via the following mechanisms:

## Ran against my test repo

I was able to successfully run this against the `CustomWorker` interface in my repo for testing gomock w/ generics: https://github.com/bradleygore/gomock-generics-issue/blob/master/workers/custom.go

I did this using a debug entry in VSCode (so I could debug it and troubleshoot as needed) of:

```json
{
            "name": "Mockgen CustomWorker",
            "type": "go",
            "request": "launch",
            "mode": "auto",
            "program": "${workspaceFolder}/mockgen",
            "args": [
                "-source", "${userHome}/git/gomock-generics-issue/workers/custom.go",
                "-destination", "${userHome}/git/gomock-generics-issue/workers/mocks/CustomWorker.go",
                "-imports", "iface=../iface",
                "CustomWorker"
            ]
        }
```

and it successfully generate this file (which looks right to me):

```go
// Code generated by MockGen. DO NOT EDIT.
// Source: /Users/bgore/git/gomock-generics-issue/workers/custom.go

// Package mock_workers is a generated GoMock package.
package mock_workers

import (
	workers "gomock-generics-issue/workers"
	reflect "reflect"

	iface "../iface"
	gomock "github.com/golang/mock/gomock"
)

// MockCustomWorker is a mock of CustomWorker interface.
type MockCustomWorker struct {
	ctrl     *gomock.Controller
	recorder *MockCustomWorkerMockRecorder
}

// MockCustomWorkerMockRecorder is the mock recorder for MockCustomWorker.
type MockCustomWorkerMockRecorder struct {
	mock *MockCustomWorker
}

// NewMockCustomWorker creates a new mock instance.
func NewMockCustomWorker(ctrl *gomock.Controller) *MockCustomWorker {
	mock := &MockCustomWorker{ctrl: ctrl}
	mock.recorder = &MockCustomWorkerMockRecorder{mock}
	return mock
}

// EXPECT returns an object that allows the caller to indicate expected use.
func (m *MockCustomWorker) EXPECT() *MockCustomWorkerMockRecorder {
	return m.recorder
}

// DoWork mocks base method.
func (m *MockCustomWorker) DoWork(arg0 ...interface{}) iface.WorkResult[workers.CustomWorkDetail] {
	m.ctrl.T.Helper()
	varargs := []interface{}{}
	for _, a := range arg0 {
		varargs = append(varargs, a)
	}
	ret := m.ctrl.Call(m, "DoWork", varargs...)
	ret0, _ := ret[0].(iface.WorkResult[workers.CustomWorkDetail])
	return ret0
}

// DoWork indicates an expected call of DoWork.
func (mr *MockCustomWorkerMockRecorder) DoWork(arg0 ...interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoWork", reflect.TypeOf((*MockCustomWorker)(nil).DoWork), arg0...)
}

// HaveGoodTimes mocks base method.
func (m *MockCustomWorker) HaveGoodTimes() {
	m.ctrl.T.Helper()
	m.ctrl.Call(m, "HaveGoodTimes")
}

// HaveGoodTimes indicates an expected call of HaveGoodTimes.
func (mr *MockCustomWorkerMockRecorder) HaveGoodTimes() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HaveGoodTimes", reflect.TypeOf((*MockCustomWorker)(nil).HaveGoodTimes))
}
```

## gomock generics test

I added a new interface to `mockgen/internal/tests/generics/generics.go` of:

```go
type EmbeddingIface interface {
	Bar[other.Three, error]
	other.Otherer[StructType, other.Five]
	LocalFunc() error
}
```

and used the following VSCode debug entry to execute these updates against it:

```json
{
    "name": "Mockgen generics",
    "type": "go",
    "request": "launch",
    "mode": "auto",
    "program": "${workspaceFolder}/mockgen",
    "args": [
        "-source", "${workspaceFolder}/mockgen/internal/tests/generics/generics.go",
        "-destination", "${workspaceFolder}/mockgen/_local/EmbeddedIfaceGenerics.go",
        "-package", "source",
        "-imports", "other=./other",
        "EmbeddingIface"
    ]
}
```
and this is the resulting output:

```go
// Code generated by MockGen. DO NOT EDIT.
// Source: /Users/bgore/git/bdg-gomock/mockgen/internal/tests/generics/generics.go

// Package source is a generated GoMock package.
package source

import (
	reflect "reflect"

	other "./other"
	gomock "github.com/golang/mock/gomock"
	generics "github.com/golang/mock/mockgen/internal/tests/generics"
)

// MockBar is a mock of Bar interface.
type MockBar[T any, R any] struct {
	ctrl     *gomock.Controller
	recorder *MockBarMockRecorder[T, R]
}

// MockBarMockRecorder is the mock recorder for MockBar.
type MockBarMockRecorder[T any, R any] struct {
	mock *MockBar[T, R]
}

// NewMockBar creates a new mock instance.
func NewMockBar[T any, R any](ctrl *gomock.Controller) *MockBar[T, R] {
	mock := &MockBar[T, R]{ctrl: ctrl}
	mock.recorder = &MockBarMockRecorder[T, R]{mock}
	return mock
}

// EXPECT returns an object that allows the caller to indicate expected use.
func (m *MockBar[T, R]) EXPECT() *MockBarMockRecorder[T, R] {
	return m.recorder
}

// Eight mocks base method.
func (m *MockBar[T, R]) Eight(arg0 T) other.Two[T, R] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Eight", arg0)
	ret0, _ := ret[0].(other.Two[T, R])
	return ret0
}

// Eight indicates an expected call of Eight.
func (mr *MockBarMockRecorder[T, R]) Eight(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eight", reflect.TypeOf((*MockBar[T, R])(nil).Eight), arg0)
}

// Eighteen mocks base method.
func (m *MockBar[T, R]) Eighteen() (generics.Iface[*other.Five], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Eighteen")
	ret0, _ := ret[0].(generics.Iface[*other.Five])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Eighteen indicates an expected call of Eighteen.
func (mr *MockBarMockRecorder[T, R]) Eighteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eighteen", reflect.TypeOf((*MockBar[T, R])(nil).Eighteen))
}

// Eleven mocks base method.
func (m *MockBar[T, R]) Eleven() (*other.One[T], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Eleven")
	ret0, _ := ret[0].(*other.One[T])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Eleven indicates an expected call of Eleven.
func (mr *MockBarMockRecorder[T, R]) Eleven() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eleven", reflect.TypeOf((*MockBar[T, R])(nil).Eleven))
}

// Fifteen mocks base method.
func (m *MockBar[T, R]) Fifteen() (generics.Iface[generics.StructType], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Fifteen")
	ret0, _ := ret[0].(generics.Iface[generics.StructType])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Fifteen indicates an expected call of Fifteen.
func (mr *MockBarMockRecorder[T, R]) Fifteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fifteen", reflect.TypeOf((*MockBar[T, R])(nil).Fifteen))
}

// Five mocks base method.
func (m *MockBar[T, R]) Five(arg0 T) generics.Baz[T] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Five", arg0)
	ret0, _ := ret[0].(generics.Baz[T])
	return ret0
}

// Five indicates an expected call of Five.
func (mr *MockBarMockRecorder[T, R]) Five(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Five", reflect.TypeOf((*MockBar[T, R])(nil).Five), arg0)
}

// Four mocks base method.
func (m *MockBar[T, R]) Four(arg0 T) generics.Foo[T, R] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Four", arg0)
	ret0, _ := ret[0].(generics.Foo[T, R])
	return ret0
}

// Four indicates an expected call of Four.
func (mr *MockBarMockRecorder[T, R]) Four(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Four", reflect.TypeOf((*MockBar[T, R])(nil).Four), arg0)
}

// Fourteen mocks base method.
func (m *MockBar[T, R]) Fourteen() (*generics.Foo[generics.StructType, generics.StructType2], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Fourteen")
	ret0, _ := ret[0].(*generics.Foo[generics.StructType, generics.StructType2])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Fourteen indicates an expected call of Fourteen.
func (mr *MockBarMockRecorder[T, R]) Fourteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fourteen", reflect.TypeOf((*MockBar[T, R])(nil).Fourteen))
}

// Nine mocks base method.
func (m *MockBar[T, R]) Nine(arg0 generics.Iface[T]) {
	m.ctrl.T.Helper()
	m.ctrl.Call(m, "Nine", arg0)
}

// Nine indicates an expected call of Nine.
func (mr *MockBarMockRecorder[T, R]) Nine(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nine", reflect.TypeOf((*MockBar[T, R])(nil).Nine), arg0)
}

// Nineteen mocks base method.
func (m *MockBar[T, R]) Nineteen() generics.AliasType {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Nineteen")
	ret0, _ := ret[0].(generics.AliasType)
	return ret0
}

// Nineteen indicates an expected call of Nineteen.
func (mr *MockBarMockRecorder[T, R]) Nineteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nineteen", reflect.TypeOf((*MockBar[T, R])(nil).Nineteen))
}

// One mocks base method.
func (m *MockBar[T, R]) One(arg0 string) string {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "One", arg0)
	ret0, _ := ret[0].(string)
	return ret0
}

// One indicates an expected call of One.
func (mr *MockBarMockRecorder[T, R]) One(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockBar[T, R])(nil).One), arg0)
}

// Seven mocks base method.
func (m *MockBar[T, R]) Seven(arg0 T) other.One[T] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Seven", arg0)
	ret0, _ := ret[0].(other.One[T])
	return ret0
}

// Seven indicates an expected call of Seven.
func (mr *MockBarMockRecorder[T, R]) Seven(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seven", reflect.TypeOf((*MockBar[T, R])(nil).Seven), arg0)
}

// Seventeen mocks base method.
func (m *MockBar[T, R]) Seventeen() (*generics.Foo[other.Three, other.Four], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Seventeen")
	ret0, _ := ret[0].(*generics.Foo[other.Three, other.Four])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Seventeen indicates an expected call of Seventeen.
func (mr *MockBarMockRecorder[T, R]) Seventeen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seventeen", reflect.TypeOf((*MockBar[T, R])(nil).Seventeen))
}

// Six mocks base method.
func (m *MockBar[T, R]) Six(arg0 T) *generics.Baz[T] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Six", arg0)
	ret0, _ := ret[0].(*generics.Baz[T])
	return ret0
}

// Six indicates an expected call of Six.
func (mr *MockBarMockRecorder[T, R]) Six(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Six", reflect.TypeOf((*MockBar[T, R])(nil).Six), arg0)
}

// Sixteen mocks base method.
func (m *MockBar[T, R]) Sixteen() (generics.Baz[other.Three], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Sixteen")
	ret0, _ := ret[0].(generics.Baz[other.Three])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Sixteen indicates an expected call of Sixteen.
func (mr *MockBarMockRecorder[T, R]) Sixteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sixteen", reflect.TypeOf((*MockBar[T, R])(nil).Sixteen))
}

// Ten mocks base method.
func (m *MockBar[T, R]) Ten(arg0 *T) {
	m.ctrl.T.Helper()
	m.ctrl.Call(m, "Ten", arg0)
}

// Ten indicates an expected call of Ten.
func (mr *MockBarMockRecorder[T, R]) Ten(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ten", reflect.TypeOf((*MockBar[T, R])(nil).Ten), arg0)
}

// Thirteen mocks base method.
func (m *MockBar[T, R]) Thirteen() (generics.Baz[generics.StructType], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Thirteen")
	ret0, _ := ret[0].(generics.Baz[generics.StructType])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Thirteen indicates an expected call of Thirteen.
func (mr *MockBarMockRecorder[T, R]) Thirteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Thirteen", reflect.TypeOf((*MockBar[T, R])(nil).Thirteen))
}

// Three mocks base method.
func (m *MockBar[T, R]) Three(arg0 T) R {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Three", arg0)
	ret0, _ := ret[0].(R)
	return ret0
}

// Three indicates an expected call of Three.
func (mr *MockBarMockRecorder[T, R]) Three(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Three", reflect.TypeOf((*MockBar[T, R])(nil).Three), arg0)
}

// Twelve mocks base method.
func (m *MockBar[T, R]) Twelve() (*other.Two[T, R], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Twelve")
	ret0, _ := ret[0].(*other.Two[T, R])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Twelve indicates an expected call of Twelve.
func (mr *MockBarMockRecorder[T, R]) Twelve() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Twelve", reflect.TypeOf((*MockBar[T, R])(nil).Twelve))
}

// Two mocks base method.
func (m *MockBar[T, R]) Two(arg0 T) string {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Two", arg0)
	ret0, _ := ret[0].(string)
	return ret0
}

// Two indicates an expected call of Two.
func (mr *MockBarMockRecorder[T, R]) Two(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Two", reflect.TypeOf((*MockBar[T, R])(nil).Two), arg0)
}

// MockIface is a mock of Iface interface.
type MockIface[T any] struct {
	ctrl     *gomock.Controller
	recorder *MockIfaceMockRecorder[T]
}

// MockIfaceMockRecorder is the mock recorder for MockIface.
type MockIfaceMockRecorder[T any] struct {
	mock *MockIface[T]
}

// NewMockIface creates a new mock instance.
func NewMockIface[T any](ctrl *gomock.Controller) *MockIface[T] {
	mock := &MockIface[T]{ctrl: ctrl}
	mock.recorder = &MockIfaceMockRecorder[T]{mock}
	return mock
}

// EXPECT returns an object that allows the caller to indicate expected use.
func (m *MockIface[T]) EXPECT() *MockIfaceMockRecorder[T] {
	return m.recorder
}

// MockEmbeddingIface is a mock of EmbeddingIface interface.
type MockEmbeddingIface struct {
	ctrl     *gomock.Controller
	recorder *MockEmbeddingIfaceMockRecorder
}

// MockEmbeddingIfaceMockRecorder is the mock recorder for MockEmbeddingIface.
type MockEmbeddingIfaceMockRecorder struct {
	mock *MockEmbeddingIface
}

// NewMockEmbeddingIface creates a new mock instance.
func NewMockEmbeddingIface(ctrl *gomock.Controller) *MockEmbeddingIface {
	mock := &MockEmbeddingIface{ctrl: ctrl}
	mock.recorder = &MockEmbeddingIfaceMockRecorder{mock}
	return mock
}

// EXPECT returns an object that allows the caller to indicate expected use.
func (m *MockEmbeddingIface) EXPECT() *MockEmbeddingIfaceMockRecorder {
	return m.recorder
}

// DoR mocks base method.
func (m *MockEmbeddingIface) DoR(arg0 R) error {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "DoR", arg0)
	ret0, _ := ret[0].(error)
	return ret0
}

// DoR indicates an expected call of DoR.
func (mr *MockEmbeddingIfaceMockRecorder) DoR(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoR", reflect.TypeOf((*MockEmbeddingIface)(nil).DoR), arg0)
}

// DoT mocks base method.
func (m *MockEmbeddingIface) DoT(arg0 T) error {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "DoT", arg0)
	ret0, _ := ret[0].(error)
	return ret0
}

// DoT indicates an expected call of DoT.
func (mr *MockEmbeddingIfaceMockRecorder) DoT(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoT", reflect.TypeOf((*MockEmbeddingIface)(nil).DoT), arg0)
}

// Eight mocks base method.
func (m *MockEmbeddingIface) Eight(arg0 T) other.Two[other.Three, error] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Eight", arg0)
	ret0, _ := ret[0].(other.Two[other.Three, error])
	return ret0
}

// Eight indicates an expected call of Eight.
func (mr *MockEmbeddingIfaceMockRecorder) Eight(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eight", reflect.TypeOf((*MockEmbeddingIface)(nil).Eight), arg0)
}

// Eighteen mocks base method.
func (m *MockEmbeddingIface) Eighteen() (generics.Iface[*other.Five], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Eighteen")
	ret0, _ := ret[0].(generics.Iface[*other.Five])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Eighteen indicates an expected call of Eighteen.
func (mr *MockEmbeddingIfaceMockRecorder) Eighteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eighteen", reflect.TypeOf((*MockEmbeddingIface)(nil).Eighteen))
}

// Eleven mocks base method.
func (m *MockEmbeddingIface) Eleven() (*other.One[T], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Eleven")
	ret0, _ := ret[0].(*other.One[T])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Eleven indicates an expected call of Eleven.
func (mr *MockEmbeddingIfaceMockRecorder) Eleven() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Eleven", reflect.TypeOf((*MockEmbeddingIface)(nil).Eleven))
}

// Fifteen mocks base method.
func (m *MockEmbeddingIface) Fifteen() (generics.Iface[generics.StructType], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Fifteen")
	ret0, _ := ret[0].(generics.Iface[generics.StructType])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Fifteen indicates an expected call of Fifteen.
func (mr *MockEmbeddingIfaceMockRecorder) Fifteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fifteen", reflect.TypeOf((*MockEmbeddingIface)(nil).Fifteen))
}

// Five mocks base method.
func (m *MockEmbeddingIface) Five(arg0 T) generics.Baz[other.Three] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Five", arg0)
	ret0, _ := ret[0].(generics.Baz[other.Three])
	return ret0
}

// Five indicates an expected call of Five.
func (mr *MockEmbeddingIfaceMockRecorder) Five(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Five", reflect.TypeOf((*MockEmbeddingIface)(nil).Five), arg0)
}

// Four mocks base method.
func (m *MockEmbeddingIface) Four(arg0 T) generics.Foo[other.Three, error] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Four", arg0)
	ret0, _ := ret[0].(generics.Foo[other.Three, error])
	return ret0
}

// Four indicates an expected call of Four.
func (mr *MockEmbeddingIfaceMockRecorder) Four(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Four", reflect.TypeOf((*MockEmbeddingIface)(nil).Four), arg0)
}

// Fourteen mocks base method.
func (m *MockEmbeddingIface) Fourteen() (*generics.Foo[generics.StructType, generics.StructType2], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Fourteen")
	ret0, _ := ret[0].(*generics.Foo[generics.StructType, generics.StructType2])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Fourteen indicates an expected call of Fourteen.
func (mr *MockEmbeddingIfaceMockRecorder) Fourteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fourteen", reflect.TypeOf((*MockEmbeddingIface)(nil).Fourteen))
}

// LocalFunc mocks base method.
func (m *MockEmbeddingIface) LocalFunc() error {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "LocalFunc")
	ret0, _ := ret[0].(error)
	return ret0
}

// LocalFunc indicates an expected call of LocalFunc.
func (mr *MockEmbeddingIfaceMockRecorder) LocalFunc() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LocalFunc", reflect.TypeOf((*MockEmbeddingIface)(nil).LocalFunc))
}

// MakeThem mocks base method.
func (m *MockEmbeddingIface) MakeThem() (T, R, error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "MakeThem")
	ret0, _ := ret[0].(T)
	ret1, _ := ret[1].(R)
	ret2, _ := ret[2].(error)
	return ret0, ret1, ret2
}

// MakeThem indicates an expected call of MakeThem.
func (mr *MockEmbeddingIfaceMockRecorder) MakeThem() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeThem", reflect.TypeOf((*MockEmbeddingIface)(nil).MakeThem))
}

// Nine mocks base method.
func (m *MockEmbeddingIface) Nine(arg0 generics.Iface[other.Three]) {
	m.ctrl.T.Helper()
	m.ctrl.Call(m, "Nine", arg0)
}

// Nine indicates an expected call of Nine.
func (mr *MockEmbeddingIfaceMockRecorder) Nine(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nine", reflect.TypeOf((*MockEmbeddingIface)(nil).Nine), arg0)
}

// Nineteen mocks base method.
func (m *MockEmbeddingIface) Nineteen() generics.AliasType {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Nineteen")
	ret0, _ := ret[0].(generics.AliasType)
	return ret0
}

// Nineteen indicates an expected call of Nineteen.
func (mr *MockEmbeddingIfaceMockRecorder) Nineteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nineteen", reflect.TypeOf((*MockEmbeddingIface)(nil).Nineteen))
}

// One mocks base method.
func (m *MockEmbeddingIface) One(arg0 string) string {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "One", arg0)
	ret0, _ := ret[0].(string)
	return ret0
}

// One indicates an expected call of One.
func (mr *MockEmbeddingIfaceMockRecorder) One(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "One", reflect.TypeOf((*MockEmbeddingIface)(nil).One), arg0)
}

// Seven mocks base method.
func (m *MockEmbeddingIface) Seven(arg0 T) other.One[other.Three] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Seven", arg0)
	ret0, _ := ret[0].(other.One[other.Three])
	return ret0
}

// Seven indicates an expected call of Seven.
func (mr *MockEmbeddingIfaceMockRecorder) Seven(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seven", reflect.TypeOf((*MockEmbeddingIface)(nil).Seven), arg0)
}

// Seventeen mocks base method.
func (m *MockEmbeddingIface) Seventeen() (*generics.Foo[other.Three, other.Four], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Seventeen")
	ret0, _ := ret[0].(*generics.Foo[other.Three, other.Four])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Seventeen indicates an expected call of Seventeen.
func (mr *MockEmbeddingIfaceMockRecorder) Seventeen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seventeen", reflect.TypeOf((*MockEmbeddingIface)(nil).Seventeen))
}

// Six mocks base method.
func (m *MockEmbeddingIface) Six(arg0 T) *generics.Baz[T] {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Six", arg0)
	ret0, _ := ret[0].(*generics.Baz[T])
	return ret0
}

// Six indicates an expected call of Six.
func (mr *MockEmbeddingIfaceMockRecorder) Six(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Six", reflect.TypeOf((*MockEmbeddingIface)(nil).Six), arg0)
}

// Sixteen mocks base method.
func (m *MockEmbeddingIface) Sixteen() (generics.Baz[other.Three], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Sixteen")
	ret0, _ := ret[0].(generics.Baz[other.Three])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Sixteen indicates an expected call of Sixteen.
func (mr *MockEmbeddingIfaceMockRecorder) Sixteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sixteen", reflect.TypeOf((*MockEmbeddingIface)(nil).Sixteen))
}

// Ten mocks base method.
func (m *MockEmbeddingIface) Ten(arg0 *T) {
	m.ctrl.T.Helper()
	m.ctrl.Call(m, "Ten", arg0)
}

// Ten indicates an expected call of Ten.
func (mr *MockEmbeddingIfaceMockRecorder) Ten(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ten", reflect.TypeOf((*MockEmbeddingIface)(nil).Ten), arg0)
}

// Thirteen mocks base method.
func (m *MockEmbeddingIface) Thirteen() (generics.Baz[generics.StructType], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Thirteen")
	ret0, _ := ret[0].(generics.Baz[generics.StructType])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Thirteen indicates an expected call of Thirteen.
func (mr *MockEmbeddingIfaceMockRecorder) Thirteen() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Thirteen", reflect.TypeOf((*MockEmbeddingIface)(nil).Thirteen))
}

// Three mocks base method.
func (m *MockEmbeddingIface) Three(arg0 T) R {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Three", arg0)
	ret0, _ := ret[0].(R)
	return ret0
}

// Three indicates an expected call of Three.
func (mr *MockEmbeddingIfaceMockRecorder) Three(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Three", reflect.TypeOf((*MockEmbeddingIface)(nil).Three), arg0)
}

// Twelve mocks base method.
func (m *MockEmbeddingIface) Twelve() (*other.Two[T, R], error) {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Twelve")
	ret0, _ := ret[0].(*other.Two[T, R])
	ret1, _ := ret[1].(error)
	return ret0, ret1
}

// Twelve indicates an expected call of Twelve.
func (mr *MockEmbeddingIfaceMockRecorder) Twelve() *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Twelve", reflect.TypeOf((*MockEmbeddingIface)(nil).Twelve))
}

// Two mocks base method.
func (m *MockEmbeddingIface) Two(arg0 T) string {
	m.ctrl.T.Helper()
	ret := m.ctrl.Call(m, "Two", arg0)
	ret0, _ := ret[0].(string)
	return ret0
}

// Two indicates an expected call of Two.
func (mr *MockEmbeddingIfaceMockRecorder) Two(arg0 interface{}) *gomock.Call {
	mr.mock.ctrl.T.Helper()
	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Two", reflect.TypeOf((*MockEmbeddingIface)(nil).Two), arg0)
}

```